### PR TITLE
feat(nav): add layout customization and fix text alignment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,6 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
-            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/main/java/com/d4viddf/hyperbridge/models/NavContent.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/models/NavContent.kt
@@ -1,0 +1,9 @@
+package com.d4viddf.hyperbridge.models
+
+enum class NavContent {
+    INSTRUCTION,    // "Turn Right"
+    DISTANCE,       // "200m"
+    ETA,            // "10:30"
+    DISTANCE_ETA,   // "200m • 10:30"
+    NONE            // Empty
+}

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/BaseTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/BaseTranslator.kt
@@ -3,12 +3,13 @@ package com.d4viddf.hyperbridge.service.translators
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Icon
 import android.service.notification.StatusBarNotification
 import android.util.Log
-import androidx.core.graphics.toColorInt
+import androidx.core.content.ContextCompat
 import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.models.BridgeAction
 import io.github.d4viddf.hyperisland_kit.HyperAction
@@ -17,30 +18,29 @@ import androidx.core.graphics.createBitmap
 
 abstract class BaseTranslator(protected val context: Context) {
 
-    /**
-     * Creates a colored version of a drawable resource (e.g., Green Tick).
-     */
+    protected fun getTransparentPicture(key: String): HyperPicture {
+        val conf = Bitmap.Config.ARGB_8888
+        val transparentBitmap = Bitmap.createBitmap(48, 48, conf)
+        return HyperPicture(key, transparentBitmap)
+    }
+
     protected fun getColoredPicture(key: String, resId: Int, colorHex: String): HyperPicture {
-        val drawable = context.getDrawable(resId)?.mutate()
-        val color = colorHex.toColorInt()
-
+        val drawable = ContextCompat.getDrawable(context, resId)?.mutate()
+        val color = Color.parseColor(colorHex)
         drawable?.setTint(color)
-        // Or for older APIs: drawable?.setColorFilter(color, PorterDuff.Mode.SRC_IN)
-
         val bitmap = drawable?.toBitmap() ?: createFallbackBitmap()
         return HyperPicture(key, bitmap)
     }
 
-    protected fun getTransparentPicture(key: String): HyperPicture {
-        val conf = Bitmap.Config.ARGB_8888
-        val transparentBitmap = createBitmap(1, 1, conf)
-        return HyperPicture(key, transparentBitmap)
+    // Helper to create HyperPicture from Resource ID safely
+    protected fun getPictureFromResource(key: String, resId: Int): HyperPicture {
+        val drawable = ContextCompat.getDrawable(context, resId)
+        val bitmap = drawable?.toBitmap() ?: createFallbackBitmap()
+        return HyperPicture(key, bitmap)
     }
 
-    // ... (Keep resolveIcon, extractBridgeActions, loadIconBitmap, getAppIconBitmap) ...
-    // ... ensure you keep the existing code below ...
-
-    protected fun resolveIcon(sbn: StatusBarNotification, picKey: String): HyperPicture {
+    // This was missing in your file, causing the error
+    protected fun getNotificationBitmap(sbn: StatusBarNotification): Bitmap? {
         var bitmap: Bitmap? = null
         try {
             val largeIcon = sbn.notification.getLargeIcon()
@@ -48,14 +48,20 @@ abstract class BaseTranslator(protected val context: Context) {
             if (bitmap == null && sbn.notification.smallIcon != null) bitmap = loadIconBitmap(sbn.notification.smallIcon)
             if (bitmap == null) bitmap = getAppIconBitmap(sbn.packageName)
         } catch (e: Exception) { Log.e("HyperBridge", "Icon error", e) }
+        return bitmap
+    }
 
+    protected fun resolveIcon(sbn: StatusBarNotification, picKey: String): HyperPicture {
+        val bitmap = getNotificationBitmap(sbn)
         return if (bitmap != null) HyperPicture(picKey, bitmap)
-        else HyperPicture(picKey, context, R.drawable.ic_launcher_foreground)
+        else getPictureFromResource(picKey, R.drawable.ic_launcher_foreground)
     }
 
     protected fun extractBridgeActions(sbn: StatusBarNotification): List<BridgeAction> {
         val bridgeActions = mutableListOf<BridgeAction>()
-        sbn.notification.actions?.forEachIndexed { index, androidAction ->
+        val actions = sbn.notification.actions ?: return emptyList()
+
+        actions.forEachIndexed { index, androidAction ->
             if (!androidAction.title.isNullOrEmpty()) {
                 val uniqueKey = "act_${sbn.key.hashCode()}_$index"
                 var actionIcon: Icon? = null
@@ -77,6 +83,7 @@ abstract class BaseTranslator(protected val context: Context) {
                     pendingIntent = androidAction.actionIntent,
                     actionIntentType = 1
                 )
+
                 bridgeActions.add(BridgeAction(hyperAction, hyperPic))
             }
         }
@@ -84,16 +91,14 @@ abstract class BaseTranslator(protected val context: Context) {
     }
 
     private fun loadIconBitmap(icon: Icon): Bitmap? = try { icon.loadDrawable(context)?.toBitmap() } catch (e: Exception) { null }
-
     private fun getAppIconBitmap(packageName: String): Bitmap? = try { context.packageManager.getApplicationIcon(packageName).toBitmap() } catch (e: Exception) { null }
-
     private fun createFallbackBitmap(): Bitmap = createBitmap(1, 1)
 
     private fun Drawable.toBitmap(): Bitmap {
         if (this is BitmapDrawable && this.bitmap != null) return this.bitmap
         val width = if (intrinsicWidth > 0) intrinsicWidth else 1
         val height = if (intrinsicHeight > 0) intrinsicHeight else 1
-        val bitmap = createBitmap(width, height)
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         setBounds(0, 0, canvas.width, canvas.height)
         draw(canvas)

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/NavTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/NavTranslator.kt
@@ -6,6 +6,7 @@ import android.service.notification.StatusBarNotification
 import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.models.HyperIslandData
 import com.d4viddf.hyperbridge.models.IslandConfig
+import com.d4viddf.hyperbridge.models.NavContent
 import io.github.d4viddf.hyperisland_kit.HyperIslandNotification
 import io.github.d4viddf.hyperisland_kit.models.ImageTextInfoLeft
 import io.github.d4viddf.hyperisland_kit.models.ImageTextInfoRight
@@ -14,57 +15,50 @@ import io.github.d4viddf.hyperisland_kit.models.TextInfo
 
 class NavTranslator(context: Context) : BaseTranslator(context) {
 
-    // Load keywords from resources (Localized)
-    private val arrivalKeywords by lazy {
-        context.resources.getStringArray(R.array.nav_arrival_keywords).toList()
-    }
-
+    private val arrivalKeywords by lazy { context.resources.getStringArray(R.array.nav_arrival_keywords).toList() }
     private val timeRegex = Regex("\\d{1,2}:\\d{2}")
 
-    fun translate(sbn: StatusBarNotification, picKey: String, config: IslandConfig): HyperIslandData {
+    fun translate(
+        sbn: StatusBarNotification,
+        picKey: String,
+        config: IslandConfig,
+        leftLayout: NavContent,
+        rightLayout: NavContent
+    ): HyperIslandData {
+
         val extras = sbn.notification.extras
 
-        val title = extras.getCharSequence(Notification.EXTRA_TITLE)?.toString() ?: ""
-        val text = extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() ?: ""
-        val subText = extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString() ?: ""
+        // Sanitize inputs (Remove newlines that break layout)
+        val title = (extras.getCharSequence(Notification.EXTRA_TITLE)?.toString() ?: "").replace("\n", " ").trim()
+        val text = (extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() ?: "").replace("\n", " ").trim()
+        val subText = (extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString() ?: "").replace("\n", " ").trim()
 
-        // 1. Progress (Shade Only)
+        // 1. Progress
         val max = extras.getInt(Notification.EXTRA_PROGRESS_MAX, 0)
         val current = extras.getInt(Notification.EXTRA_PROGRESS, 0)
         val hasProgress = max > 0
         val percent = if (hasProgress) ((current.toFloat() / max.toFloat()) * 100).toInt() else 0
 
         // 2. Text Analysis
-        var instruction: String
+        var instruction = ""
         var distance = ""
         var eta = ""
 
-        fun isTimeInfo(s: String): Boolean {
-            return timeRegex.containsMatchIn(s) || arrivalKeywords.any { s.contains(it, true) }
-        }
+        fun isTimeInfo(s: String): Boolean = timeRegex.containsMatchIn(s) || arrivalKeywords.any { s.contains(it, true) }
 
         // Find ETA
         if (isTimeInfo(subText)) eta = subText
-        else if (isTimeInfo(text)) eta = text
-        else if (isTimeInfo(title)) eta = title
-
-        // Find Instruction vs Distance
-        if (eta != text && eta != title) {
-            if (text.isNotEmpty() && title.isNotEmpty()) {
-                // Heuristic: Instruction is longer than distance
-                if (title.length >= text.length) {
-                    instruction = title
-                    distance = text
-                } else {
-                    instruction = text
-                    distance = title
-                }
-            } else {
-                instruction = if (title.isNotEmpty()) title else text
+        if (text.isNotEmpty() && title.isNotEmpty()) {
+            if (eta.isEmpty()) {
+                if (isTimeInfo(text)) { eta = text; instruction = title }
+                else if (isTimeInfo(title)) { eta = title; instruction = text }
+            }
+            if (instruction.isEmpty()) {
+                if (title.length >= text.length) { instruction = title; distance = text }
+                else { instruction = text; distance = title }
             }
         } else {
-            // One field was ETA, the other is Instruction
-            instruction = if (eta == text) title else text
+            instruction = if (title.isNotEmpty()) title else text
         }
 
         if (instruction.isEmpty()) instruction = context.getString(R.string.maps_title)
@@ -72,9 +66,10 @@ class NavTranslator(context: Context) : BaseTranslator(context) {
         val builder = HyperIslandNotification.Builder(context, "bridge_${sbn.packageName}", instruction)
 
         // --- CONFIG ---
-        // Uncomment when library updated
         val finalTimeout = config.timeout ?: 5000L
-        builder.setEnableFloat(config.isFloat?: true)
+        val shouldFloat = if (finalTimeout == 0L) false else (config.isFloat ?: true)
+
+        builder.setEnableFloat(shouldFloat)
         builder.setTimeout(finalTimeout)
         builder.setShowNotification(config.isShowShade ?: true)
 
@@ -87,7 +82,7 @@ class NavTranslator(context: Context) : BaseTranslator(context) {
         val actions = extractBridgeActions(sbn)
         val actionKeys = actions.map { it.action.key }
 
-        // --- 3. EXPANDED INFO (SHADE) ---
+        // Shade Info (Combined)
         val shadeContent = listOf(distance, eta).filter { it.isNotEmpty() }.joinToString(" • ")
         builder.setBaseInfo(
             title = instruction,
@@ -96,43 +91,7 @@ class NavTranslator(context: Context) : BaseTranslator(context) {
             actionKeys = actionKeys
         )
 
-        // --- 4. BIG ISLAND (SPLIT LOGIC) ---
-        var leftTitle: String
-        var leftContent: String
-        var rightText: String
-
-        if (eta.isNotEmpty()) {
-            // SCENARIO A: We have Time (ETA)
-            // Right: [ Time ]
-            // Left:  [ Arrow ] [ Instruction \n Distance ]
-            rightText = eta
-            leftTitle = instruction
-            leftContent = distance
-        } else {
-            // SCENARIO B: No Time
-            // Right: [ Distance ]
-            // Left:  [ Arrow ] [ Instruction ]
-            rightText = if (distance.isNotEmpty()) distance else ""
-            leftTitle = instruction
-            leftContent = ""
-        }
-
-        builder.setBigIslandInfo(
-            // LEFT: Arrow + Text Block
-            left = ImageTextInfoLeft(
-                1,
-                PicInfo(1, picKey),
-                TextInfo(leftTitle, leftContent)
-            ),
-            // RIGHT: Specific Data (Time or Distance) + Transparent Spacer
-            right = ImageTextInfoRight(
-                2, // Type 2 = Vertically Centered Text
-                PicInfo(1, hiddenKey),
-                TextInfo(rightText, null)
-            )
-        )
-
-        // Progress Bar (Shade Only)
+        // Progress (Shade Only)
         if (hasProgress) {
             builder.setProgressBar(
                 progress = percent,
@@ -140,6 +99,34 @@ class NavTranslator(context: Context) : BaseTranslator(context) {
                 picForwardKey = picKey
             )
         }
+
+        // --- 3. BIG ISLAND CUSTOM LAYOUT ---
+
+        // Helper to map Enum preference to Text Data
+        fun getTextInfo(type: NavContent): TextInfo {
+            return when (type) {
+                NavContent.INSTRUCTION -> TextInfo(instruction, null) // Centered
+                NavContent.DISTANCE -> TextInfo(distance, null)      // Centered
+                NavContent.ETA -> TextInfo(eta, null)                // Centered
+                NavContent.DISTANCE_ETA -> TextInfo(distance, eta)   // Top/Bottom
+                NavContent.NONE -> TextInfo("", "")
+            }
+        }
+
+        builder.setBigIslandInfo(
+            // Left Side (Icon + User Configured Text)
+            left = ImageTextInfoLeft(
+                1,
+                PicInfo(1, picKey),
+                getTextInfo(leftLayout)
+            ),
+            // Right Side (User Configured Text + Transparent Spacer)
+            right = ImageTextInfoRight(
+                2,
+                PicInfo(1, hiddenKey),
+                getTextInfo(rightLayout)
+            )
+        )
 
         builder.setSmallIslandIcon(picKey)
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/Dialogs.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -25,12 +27,11 @@ import com.d4viddf.hyperbridge.ui.AppListViewModel
 fun AppConfigBottomSheet(
     app: AppInfo,
     viewModel: AppListViewModel,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onNavConfigClick: () -> Unit
 ) {
-    // Load Notification Type Config
     val typeConfig by viewModel.getAppConfig(app.packageName).collectAsState(initial = emptySet())
 
-    // Load Appearance Configs (App + Global for fallback)
     val appIslandConfig by viewModel.getAppIslandConfig(app.packageName).collectAsState(initial = IslandConfig())
     val globalConfig by viewModel.globalConfigFlow.collectAsState(initial = IslandConfig(true, true, 5000L))
 
@@ -102,6 +103,18 @@ fun AppConfigBottomSheet(
                             fontWeight = FontWeight.SemiBold
                         )
                     }
+
+                    // Edit Button for Navigation
+                    if (type == NotificationType.NAVIGATION) {
+                        IconButton(onClick = onNavConfigClick) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "Edit Layout",
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+
                     Switch(
                         checked = isChecked,
                         onCheckedChange = { viewModel.updateAppConfig(app.packageName, type, it) }
@@ -122,7 +135,6 @@ fun AppConfigBottomSheet(
             )
             Spacer(modifier = Modifier.height(8.dp))
 
-            // "Use Global Defaults" Checkbox
             val isUsingGlobal = appIslandConfig.isFloat == null
 
             Row(
@@ -130,10 +142,8 @@ fun AppConfigBottomSheet(
                     .fillMaxWidth()
                     .clickable {
                         if (isUsingGlobal) {
-                            // Enable Custom: Initialize with current global values
                             viewModel.updateAppIslandConfig(app.packageName, globalConfig)
                         } else {
-                            // Disable Custom: Reset to null (Inherit)
                             viewModel.updateAppIslandConfig(app.packageName, IslandConfig(null, null, null))
                         }
                     }
@@ -145,7 +155,6 @@ fun AppConfigBottomSheet(
                 Text(stringResource(R.string.use_global_default), style = MaterialTheme.typography.bodyLarge)
             }
 
-            // Settings Controls (Visible only if Custom)
             if (!isUsingGlobal) {
                 Card(
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/HomeScreen.kt
@@ -37,7 +37,8 @@ import com.d4viddf.hyperbridge.ui.components.AppConfigBottomSheet
 @Composable
 fun HomeScreen(
     viewModel: AppListViewModel = viewModel(),
-    onSettingsClick: () -> Unit
+    onSettingsClick: () -> Unit,
+    onNavConfigClick: (String) -> Unit
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
 
@@ -45,6 +46,7 @@ fun HomeScreen(
     val libraryApps by viewModel.libraryAppsState.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
 
+    // State to hold the app being configured
     var configApp by remember { mutableStateOf<com.d4viddf.hyperbridge.ui.AppInfo?>(null) }
 
     Scaffold(
@@ -85,11 +87,21 @@ fun HomeScreen(
         }
     }
 
+    // --- BOTTOM SHEET HANDLER (CRASH FIX) ---
     if (configApp != null) {
+        // Capture the non-null app object locally
+        val safeApp = configApp!!
+
         AppConfigBottomSheet(
-            app = configApp!!,
+            app = safeApp,
             viewModel = viewModel,
-            onDismiss = { configApp = null }
+            onDismiss = { configApp = null },
+            onNavConfigClick = {
+                // 1. Trigger Navigation using the SAFE local variable
+                onNavConfigClick(safeApp.packageName)
+                // 2. Close Sheet
+                configApp = null
+            }
         )
     }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalSettingsScreen.kt
@@ -3,6 +3,7 @@ package com.d4viddf.hyperbridge.ui.screens.settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -17,7 +18,10 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GlobalSettingsScreen(onBack: () -> Unit) {
+fun GlobalSettingsScreen(
+    onBack: () -> Unit,
+    onNavSettingsClick: () -> Unit // New Callback
+    ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val preferences = remember { AppPreferences(context) }
@@ -48,6 +52,17 @@ fun GlobalSettingsScreen(onBack: () -> Unit) {
                         }
                     )
                 }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // NEW: Navigation Layout Card
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh)) {
+                SettingsItem(
+                    icon = Icons.Default.Navigation,
+                    title = stringResource(R.string.nav_layout_title),
+                    subtitle = stringResource(R.string.nav_layout_desc),
+                    onClick = onNavSettingsClick
+                )
             }
         }
     }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/NavCustomizationScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/NavCustomizationScreen.kt
@@ -1,0 +1,319 @@
+package com.d4viddf.hyperbridge.ui.screens.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.TurnRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.data.AppPreferences
+import com.d4viddf.hyperbridge.models.NavContent
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NavCustomizationScreen(
+    onBack: () -> Unit,
+    packageName: String? = null
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val preferences = remember { AppPreferences(context) }
+
+    val globalLayout by preferences.globalNavLayoutFlow.collectAsState(initial = NavContent.DISTANCE_ETA to NavContent.INSTRUCTION)
+
+    val appLayout by if (packageName != null) {
+        preferences.getAppNavLayout(packageName).collectAsState(initial = null to null)
+    } else {
+        remember { mutableStateOf(null to null) }
+    }
+
+    val isGlobalMode = packageName == null
+    val isUsingGlobalDefault = !isGlobalMode && appLayout.first == null
+
+    val currentLeft = if (isGlobalMode || isUsingGlobalDefault) globalLayout.first else (appLayout.first ?: globalLayout.first)
+    val currentRight = if (isGlobalMode || isUsingGlobalDefault) globalLayout.second else (appLayout.second ?: globalLayout.second)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.nav_layout_title)) },
+                navigationIcon = {
+                    FilledTonalIconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).padding(16.dp)) {
+
+            // PREVIEW
+            Text("Preview", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            NavPreview(currentLeft, currentRight)
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            // CONFIGURATION
+            Text(stringResource(R.string.group_configuration), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (!isGlobalMode) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            if (isUsingGlobalDefault) {
+                                scope.launch { preferences.updateAppNavLayout(packageName, globalLayout.first, globalLayout.second) }
+                            } else {
+                                scope.launch { preferences.updateAppNavLayout(packageName, null, null) }
+                            }
+                        }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(checked = isUsingGlobalDefault, onCheckedChange = null)
+                    Spacer(Modifier.width(12.dp))
+                    Text(stringResource(R.string.use_global_default), style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+
+            val controlsEnabled = isGlobalMode || !isUsingGlobalDefault
+
+            if (controlsEnabled) {
+                Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+                    Column(Modifier.padding(16.dp)) {
+                        NavDropdown(
+                            label = stringResource(R.string.left_content),
+                            selected = currentLeft,
+                            onSelect = { newLeft ->
+                                scope.launch {
+                                    if (isGlobalMode) preferences.setGlobalNavLayout(newLeft, currentRight)
+                                    else preferences.updateAppNavLayout(packageName, newLeft, currentRight)
+                                }
+                            }
+                        )
+                        Spacer(Modifier.height(16.dp))
+                        NavDropdown(
+                            label = stringResource(R.string.right_content),
+                            selected = currentRight,
+                            onSelect = { newRight ->
+                                scope.launch {
+                                    if (isGlobalMode) preferences.setGlobalNavLayout(currentLeft, newRight)
+                                    else preferences.updateAppNavLayout(packageName, currentLeft, newRight)
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NavPreview(left: NavContent, right: NavContent) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        shape = RoundedCornerShape(24.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 32.dp), // Breathing room
+            contentAlignment = Alignment.Center
+        ) {
+            // --- THE ISLAND (Compact Pill) ---
+            Box(
+                modifier = Modifier
+                    .width(280.dp)
+                    .height(46.dp) // FIXED: Same height as camera roughly (Pill shape)
+                    .clip(RoundedCornerShape(50)) // Fully rounded
+                    .background(Color.Black)
+            ) {
+                // --- CAMERA CUTOUT ---
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(30.dp) // Camera Size
+                        .clip(CircleShape)
+                        .background(Color(0xFF1F1F1F))
+                )
+
+                // --- CONTENT ROW ---
+                Row(
+                    modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // LEFT ZONE
+                    Row(
+                        modifier = Modifier.weight(1f),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Start
+                    ) {
+                        // Fixed Direction Icon (Always on Left)
+                        Icon(
+                            imageVector = Icons.Default.TurnRight,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+
+                        Spacer(Modifier.width(6.dp))
+
+                        // User Configured Text
+                        NavContentRenderer(left, Alignment.Start)
+                    }
+
+                    // Spacer for Camera
+                    Spacer(modifier = Modifier.width(34.dp))
+
+                    // RIGHT ZONE
+                    Box(
+                        modifier = Modifier.weight(1f),
+                        contentAlignment = Alignment.CenterEnd
+                    ) {
+                        NavContentRenderer(right, Alignment.End)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NavContentRenderer(type: NavContent, align: Alignment.Horizontal) {
+    // Font sizes adjusted for the smaller pill height
+    when (type) {
+        NavContent.INSTRUCTION -> {
+            Text(
+                text = "Turn Right",
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                maxLines = 1
+            )
+        }
+        NavContent.DISTANCE -> {
+            Text(
+                text = "200m",
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp
+            )
+        }
+        NavContent.ETA -> {
+            // FIXED: Time isn't colored green anymore, just white/grey
+            Text(
+                text = "10:30",
+                color = Color.White,
+                fontWeight = FontWeight.Normal,
+                fontSize = 14.sp
+            )
+        }
+        NavContent.DISTANCE_ETA -> {
+            // Compact layout for double info
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("200m", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+                Spacer(Modifier.width(4.dp))
+                Text("•", color = Color.Gray, fontSize = 12.sp)
+                Spacer(Modifier.width(4.dp))
+                Text("10:30", color = Color.LightGray, fontSize = 13.sp)
+            }
+        }
+        NavContent.NONE -> { /* Empty */ }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NavDropdown(label: String, selected: NavContent, onSelect: (NavContent) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Column {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
+        Spacer(Modifier.height(4.dp))
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+            OutlinedTextField(
+                value = stringResource(getNavContentLabelRes(selected)),
+                onValueChange = {},
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier.menuAnchor().fillMaxWidth(),
+                textStyle = MaterialTheme.typography.bodyMedium
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                NavContent.entries.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(getNavContentLabelRes(option))) },
+                        onClick = { onSelect(option); expanded = false }
+                    )
+                }
+            }
+        }
+    }
+}
+
+fun getMockText(type: NavContent): String {
+    return when(type) {
+        NavContent.INSTRUCTION -> "Turn Right"
+        NavContent.DISTANCE -> "200m"
+        NavContent.ETA -> "10:30"
+        NavContent.DISTANCE_ETA -> "200m • 10:30"
+        NavContent.NONE -> ""
+    }
+}
+
+private fun getNavContentLabelRes(content: NavContent): Int {
+    return when(content) {
+        NavContent.INSTRUCTION -> R.string.nav_content_instruction
+        NavContent.DISTANCE -> R.string.nav_content_distance
+        NavContent.ETA -> R.string.nav_content_eta
+        NavContent.DISTANCE_ETA -> R.string.nav_content_distance_eta
+        NavContent.NONE -> R.string.nav_content_none
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -47,7 +47,7 @@
     <string name="tab_library">Biblioteca</string>
     <string name="title_active_bridges">Bridges Activos</string>
     <string name="title_library">Biblioteca de aplicaciones</string>
-    <string name="search_hint">Buscar aplicaciones...</string>
+    <string name="search_hint">Buscar aplicaciones…</string>
     <string name="sort_az">Orden: A-Z</string>
     <string name="sort_za">Orden: Z-A</string>
 
@@ -210,4 +210,18 @@
     <string name="configure_now">Configurar</string>
 
     <string name="badge_new">NUEVO</string>
+
+    <string name="custom_design">Diseño Personalizado</string>
+    <string name="nav_layout_title">Diseño de Navegación</string>
+    <string name="nav_layout_desc">Elige dónde aparece la información</string>
+    <string name="left_content">Lado Izquierdo</string>
+    <string name="right_content">Lado Derecho</string>
+
+    <string name="nav_content_instruction">Instrucción</string>
+    <string name="nav_content_distance">Distancia</string>
+    <string name="nav_content_eta">Hora de Llegada</string>
+    <string name="nav_content_distance_eta">Dist. y Hora</string>
+    <string name="nav_content_none">Vacío</string>
+
+    <string name="channel_active_islands">Islas Activas</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,10 +102,10 @@
 
     <string name="service_active">Active</string>
     <string name="download_complete">Download Complete</string>
-    <string name="pending">Pending...</string>
+    <string name="pending">Pending…</string>
     <string name="finished">Finished</string>
     <string name="downloading">Downloading</string>
-    <string name="waiting">Waiting...</string>
+    <string name="waiting">Waiting…</string>
     <string name="now_playing">Now Playing</string>
     <string name="unknown_caller">Unknown Caller</string>
     <string name="incoming_call">Call</string>
@@ -205,4 +205,18 @@
     <string name="configure_now">Configure Now</string>
 
     <string name="badge_new">NEW</string>
+
+    <string name="custom_design">Custom Design</string>
+    <string name="nav_layout_title">Navigation Layout</string>
+    <string name="nav_layout_desc">Choose where information appears</string>
+    <string name="left_content">Left Side</string>
+    <string name="right_content">Right Side</string>
+
+    <string name="nav_content_instruction">Instruction</string>
+    <string name="nav_content_distance">Distance</string>
+    <string name="nav_content_eta">Arrival Time</string>
+    <string name="nav_content_distance_eta">Dist. &amp; Time</string>
+    <string name="nav_content_none">Empty</string>
+
+    <string name="channel_active_islands">Active Islands</string>
 </resources>


### PR DESCRIPTION
- Added `NavCustomizationScreen` with live preview to configure Navigation Island layout.
- Implemented options to customize Left/Right content (Instruction, Distance, ETA) globally or per app.
- Fixed text misalignment bug caused by newline characters in notification extras.
- Updated `NavTranslator` to sanitize inputs and respect new layout configs.
- Added Spanish translations for new settings.

Closes #4