### PR TITLE
feat(a11y): improve TalkBack support and semantic navigation

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/AppListItem.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/AppListItem.kt
@@ -13,52 +13,88 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.ui.AppInfo
 
 @Composable
 fun AppListItem(
     app: AppInfo,
-    isSimple: Boolean,
     onToggle: (Boolean) -> Unit,
     onSettingsClick: (() -> Unit)? = null
 ) {
-    // Using M3 ListItem for better native alignment
+    // Strings for A11y
+    val toggleLabel = stringResource(R.string.cd_toggle_app, app.name)
+    val settingsLabel = stringResource(R.string.cd_configure_app, app.name)
+    val activeState = stringResource(R.string.cd_app_state_active)
+    val inactiveState = stringResource(R.string.cd_app_state_inactive)
+
     ListItem(
         headlineContent = {
-            Text(app.name, fontWeight = FontWeight.SemiBold)
+            Text(
+                text = app.name,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         },
-        supportingContent = if (!isSimple) {
-            { Text(app.packageName, maxLines = 1) }
-        } else null,
+        supportingContent = {
+            Text(
+                text = app.packageName,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = Color.Gray
+            )
+        },
         leadingContent = {
+            // Mark image as decorative so TalkBack ignores it (text already says name)
             Image(
                 bitmap = app.icon.asImageBitmap(),
                 contentDescription = null,
                 modifier = Modifier
                     .size(48.dp)
-                    .clip(RoundedCornerShape(12.dp)) // M3 style squaring
+                    .clip(RoundedCornerShape(12.dp))
             )
         },
         trailingContent = {
             Row(verticalAlignment = Alignment.CenterVertically) {
+                // SETTINGS BUTTON
                 if (app.isBridged && onSettingsClick != null) {
-                    IconButton(onClick = onSettingsClick) {
+                    IconButton(
+                        onClick = onSettingsClick,
+                        // Explicitly say "Configure WhatsApp"
+                        modifier = Modifier.semantics { contentDescription = settingsLabel }
+                    ) {
                         Icon(
                             Icons.Default.Tune,
-                            contentDescription = "Configure",
+                            contentDescription = null, // Description is on the button
                             tint = MaterialTheme.colorScheme.primary
                         )
                     }
                 }
+
+                // TOGGLE SWITCH
                 Switch(
                     checked = app.isBridged,
-                    onCheckedChange = onToggle
+                    onCheckedChange = onToggle,
+
+                    modifier = Modifier.semantics {
+                        contentDescription = toggleLabel // "Toggle WhatsApp"
+                        stateDescription = if (app.isBridged) activeState else inactiveState
+                    }
                 )
             }
         },
-        modifier = Modifier.clickable { onToggle(!app.isBridged) },
+        // The whole row click also toggles, so we label the row too
+        modifier = Modifier
+            .clickable { onToggle(!app.isBridged) }
+            .semantics { contentDescription = toggleLabel },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)
     )
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/ChangelogDialog.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/ChangelogDialog.kt
@@ -1,18 +1,11 @@
 package com.d4viddf.hyperbridge.ui.components
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -20,6 +13,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.util.parseBold // Import the extension
 
 @Composable
 fun ChangelogDialog(
@@ -48,18 +42,15 @@ fun ChangelogDialog(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(max = 300.dp) // Prevent it from being too tall
+                    .heightIn(max = 300.dp)
                     .verticalScroll(rememberScrollState())
             ) {
-                // We use a simple text parser here for HTML-like tags if needed,
-                // or just render the raw string. For simplicity, we assume plain text with bullets.
-                // If you want bolding from XML, standard Text doesn't support it easily without parsing.
-                // For now, we render the string resource directly.
-
+                // FIX: Use parseBold() instead of .replace()
                 Text(
-                    text = changelogText.replace("\\n", "\n").replace("<b>", "").replace("</b>", ""),
+                    text = changelogText.parseBold(),
                     style = MaterialTheme.typography.bodyLarge,
-                    lineHeight = 24.sp
+                    lineHeight = 24.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         },

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/Dialogs.kt
@@ -14,6 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4viddf.hyperbridge.R
@@ -30,8 +33,8 @@ fun AppConfigBottomSheet(
     onDismiss: () -> Unit,
     onNavConfigClick: () -> Unit
 ) {
+    // Load states from ViewModel
     val typeConfig by viewModel.getAppConfig(app.packageName).collectAsState(initial = emptySet())
-
     val appIslandConfig by viewModel.getAppIslandConfig(app.packageName).collectAsState(initial = IslandConfig())
     val globalConfig by viewModel.globalConfigFlow.collectAsState(initial = IslandConfig(true, true, 5000L))
 
@@ -47,16 +50,18 @@ fun AppConfigBottomSheet(
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
-                .padding(bottom = 48.dp)
+                .padding(bottom = 48.dp) // Extra bottom padding for navigation bar safety
         ) {
-            // --- HEADER ---
+            // =====================================================================
+            // HEADER: App Icon and Name
+            // =====================================================================
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(bottom = 24.dp)
             ) {
                 Image(
                     bitmap = app.icon.asImageBitmap(),
-                    contentDescription = null,
+                    contentDescription = null, // Decorative: Text name is sufficient for TalkBack
                     modifier = Modifier.size(48.dp)
                 )
                 Spacer(modifier = Modifier.width(16.dp))
@@ -77,7 +82,10 @@ fun AppConfigBottomSheet(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
             Spacer(modifier = Modifier.height(16.dp))
 
-            // --- SECTION 1: NOTIFICATION TYPES ---
+            // =====================================================================
+            // SECTION 1: NOTIFICATION TYPES
+            // Toggles specific features (e.g., Disable music island for this app)
+            // =====================================================================
             Text(
                 text = stringResource(R.string.select_active_notifs),
                 style = MaterialTheme.typography.titleMedium,
@@ -88,6 +96,16 @@ fun AppConfigBottomSheet(
 
             NotificationType.entries.forEach { type ->
                 val isChecked = typeConfig.contains(type.name)
+                val typeLabel = stringResource(type.labelRes)
+
+                // ACCESSIBILITY: Pre-load strings here because we cannot call
+                // @Composable functions inside the modifier.semantics block below.
+                val switchDesc = if (isChecked)
+                    stringResource(R.string.cd_disable_type, typeLabel)
+                else
+                    stringResource(R.string.cd_enable_type, typeLabel)
+
+                val navEditDesc = stringResource(R.string.cd_nav_edit)
 
                 Row(
                     modifier = Modifier
@@ -98,18 +116,26 @@ fun AppConfigBottomSheet(
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = stringResource(type.labelRes),
+                            text = typeLabel,
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold
                         )
                     }
 
-                    // Edit Button for Navigation
+                    // Special Edit Button for Navigation Type
                     if (type == NotificationType.NAVIGATION) {
-                        IconButton(onClick = onNavConfigClick) {
+                        IconButton(
+                            onClick = {
+                                onDismiss() // Close sheet before navigating
+                                onNavConfigClick()
+                            },
+                            modifier = Modifier.semantics {
+                                contentDescription = navEditDesc
+                            }
+                        ) {
                             Icon(
                                 imageVector = Icons.Default.Edit,
-                                contentDescription = "Edit Layout",
+                                contentDescription = null, // Handled by modifier above
                                 tint = MaterialTheme.colorScheme.primary
                             )
                         }
@@ -117,7 +143,10 @@ fun AppConfigBottomSheet(
 
                     Switch(
                         checked = isChecked,
-                        onCheckedChange = { viewModel.updateAppConfig(app.packageName, type, it) }
+                        onCheckedChange = { viewModel.updateAppConfig(app.packageName, type, it) },
+                        modifier = Modifier.semantics {
+                            contentDescription = switchDesc
+                        }
                     )
                 }
             }
@@ -126,7 +155,10 @@ fun AppConfigBottomSheet(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
             Spacer(modifier = Modifier.height(24.dp))
 
-            // --- SECTION 2: ISLAND APPEARANCE ---
+            // =====================================================================
+            // SECTION 2: ISLAND APPEARANCE
+            // Override global settings (Timeout, Float) for this specific app
+            // =====================================================================
             Text(
                 text = stringResource(R.string.island_appearance),
                 style = MaterialTheme.typography.titleMedium,
@@ -135,32 +167,46 @@ fun AppConfigBottomSheet(
             )
             Spacer(modifier = Modifier.height(8.dp))
 
+            // Logic: Null means "Inherit from Global". Non-null means "Custom Override".
             val isUsingGlobal = appIslandConfig.isFloat == null
 
+            // ACCESSIBILITY: Resolve strings outside semantics block
+            val stateActive = stringResource(R.string.status_active)
+            val stateInactive = stringResource(R.string.status_finished) // Reusing "Finished" implies "Not active" context
+
+            // "Use Global Defaults" Checkbox Row
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable {
                         if (isUsingGlobal) {
+                            // Switch to Custom: Pre-fill with current global values so the UI doesn't jump
                             viewModel.updateAppIslandConfig(app.packageName, globalConfig)
                         } else {
+                            // Switch to Global: Reset to nulls
                             viewModel.updateAppIslandConfig(app.packageName, IslandConfig(null, null, null))
                         }
                     }
-                    .padding(vertical = 8.dp),
+                    .padding(vertical = 8.dp)
+                    .semantics {
+                        // Tell TalkBack if we are using global defaults or custom
+                        stateDescription = if (isUsingGlobal) stateActive else stateInactive
+                    },
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Checkbox(checked = isUsingGlobal, onCheckedChange = null)
+                Checkbox(checked = isUsingGlobal, onCheckedChange = null) // decorative, click handled by Row
                 Spacer(Modifier.width(12.dp))
                 Text(stringResource(R.string.use_global_default), style = MaterialTheme.typography.bodyLarge)
             }
 
+            // Show controls only when NOT using global defaults
             if (!isUsingGlobal) {
                 Card(
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
                     modifier = Modifier.padding(top = 8.dp).fillMaxWidth()
                 ) {
                     Column(Modifier.padding(16.dp)) {
+                        // Reusable control logic (Sliders/Switches)
                         IslandSettingsControl(
                             config = appIslandConfig,
                             onUpdate = { newConfig ->
@@ -173,7 +219,10 @@ fun AppConfigBottomSheet(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth().height(50.dp)) {
+            Button(
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth().height(50.dp)
+            ) {
                 Text(stringResource(R.string.done))
             }
         }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/ActiveAppsPage.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/ActiveAppsPage.kt
@@ -64,7 +64,6 @@ fun ActiveAppsPage(
                                 app = app,
                                 onToggle = { viewModel.toggleApp(app.packageName, false) },
                                 onSettingsClick = { onConfig(app) },
-                                isSimple = false
                             )
                             HorizontalDivider(
                                 modifier = Modifier.padding(start = 72.dp),

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/LibraryPage.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/LibraryPage.kt
@@ -62,7 +62,6 @@ fun LibraryPage(
                             app = app,
                             onToggle = { viewModel.toggleApp(app.packageName, it) },
                             onSettingsClick = { onConfig(app) },
-                            isSimple = false
                         )
                         HorizontalDivider(
                             modifier = Modifier.padding(start = 72.dp),

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/AppPriorityScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/AppPriorityScreen.kt
@@ -57,6 +57,10 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -68,8 +72,20 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+/**
+ * Simple data class to hold app metadata for the priority list.
+ * Does not hold the heavy Bitmap directly to avoid UI lag during recomposition.
+ */
 data class PriorityAppInfo(val name: String, val packageName: String)
 
+/**
+ * Screen that allows users to reorder apps to define priority.
+ *
+ * Features:
+ * - **Drag and Drop:** Custom implementation using pointerInput to handle item swapping and auto-scrolling.
+ * - **Manual Sorting:** Arrows for accessibility and precision.
+ * - **Accessibility:** Custom semantic actions for TalkBack users to "Move Up" or "Move Down".
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppPriorityScreen(onBack: () -> Unit) {
@@ -78,13 +94,15 @@ fun AppPriorityScreen(onBack: () -> Unit) {
     val preferences = remember { AppPreferences(context) }
     val packageManager = context.packageManager
 
-    val enabledPackages by preferences.allowedPackagesFlow.collectAsState(initial = emptySet())
-    val savedOrder by preferences.appPriorityListFlow.collectAsState(initial = emptyList())
+    // Load live data from DataStore
+    val enabledPackages: Set<String> by preferences.allowedPackagesFlow.collectAsState(initial = emptySet())
+    val savedOrder: List<String> by preferences.appPriorityListFlow.collectAsState(initial = emptyList())
 
+    // Mutable list required for instant drag-and-drop visual updates
     val displayList = remember { mutableStateListOf<PriorityAppInfo>() }
     var isLoaded by remember { mutableStateOf(false) }
 
-    // Load Data
+    // Merge saved priority order with currently enabled apps
     LaunchedEffect(enabledPackages, savedOrder) {
         if (enabledPackages.isEmpty()) {
             displayList.clear()
@@ -93,17 +111,20 @@ fun AppPriorityScreen(onBack: () -> Unit) {
         }
 
         withContext(Dispatchers.IO) {
+            // 1. Existing items in their saved order
             val ordered = savedOrder.filter { enabledPackages.contains(it) }
+            // 2. New items appended to the end
             val newApps = enabledPackages.filter { !savedOrder.contains(it) }
             val finalPackageList = ordered + newApps
 
+            // 3. Load Labels (Lightweight operation)
             val infoList = finalPackageList.map { pkg ->
                 try {
                     val appInfo = packageManager.getApplicationInfo(pkg, 0)
                     val name = packageManager.getApplicationLabel(appInfo).toString()
                     PriorityAppInfo(name, pkg)
                 } catch (e: Exception) {
-                    PriorityAppInfo(pkg, pkg)
+                    PriorityAppInfo(pkg, pkg) // Fallback
                 }
             }
 
@@ -134,11 +155,13 @@ fun AppPriorityScreen(onBack: () -> Unit) {
                 .fillMaxSize()
         ) {
             Spacer(modifier = Modifier.height(16.dp))
+
             Text(
                 text = stringResource(R.string.priority_order_desc),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+
             Spacer(modifier = Modifier.height(16.dp))
 
             if (!isLoaded) {
@@ -150,12 +173,15 @@ fun AppPriorityScreen(onBack: () -> Unit) {
                     Text(stringResource(R.string.no_active_bridges), color = MaterialTheme.colorScheme.error)
                 }
             } else {
+                // The main reorderable list component
                 DraggableLazyList(
                     items = displayList,
                     onMove = { from, to ->
+                        // Update local state immediately for smoothness
                         displayList.apply { add(to, removeAt(from)) }
                     },
                     onDragEnd = {
+                        // Commit changes to persistent storage
                         scope.launch {
                             preferences.setAppPriorityOrder(displayList.map { it.packageName })
                         }
@@ -166,6 +192,11 @@ fun AppPriorityScreen(onBack: () -> Unit) {
     }
 }
 
+/**
+ * A custom implementation of a Drag-and-Drop list using LazyColumn.
+ * * @param onMove Called when two items swap positions during the drag.
+ * @param onDragEnd Called when the user releases the finger (save data here).
+ */
 @Composable
 fun DraggableLazyList(
     items: List<PriorityAppInfo>,
@@ -173,21 +204,22 @@ fun DraggableLazyList(
     onDragEnd: () -> Unit
 ) {
     val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
 
     var draggingIndex by remember { mutableStateOf<Int?>(null) }
-    var dragOffset by remember { mutableStateOf(0f) }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
 
-    // Auto-scroll config
+    // Auto-scrolling setup
     val density = LocalDensity.current
-    val scrollThreshold = with(density) { 50.dp.toPx() } // Zone size at top/bottom
+    val scrollThreshold = with(density) { 60.dp.toPx() }
     var scrollVelocity by remember { mutableFloatStateOf(0f) }
 
-    // AUTO-SCROLL LOOP
+    // Coroutine to handle auto-scrolling when dragging near edges
     LaunchedEffect(scrollVelocity) {
         if (scrollVelocity != 0f) {
             while (true) {
                 listState.scrollBy(scrollVelocity)
-                delay(16) // ~60fps frame time
+                delay(16) // ~60 FPS loop
                 if (scrollVelocity == 0f) break
             }
         }
@@ -198,10 +230,11 @@ fun DraggableLazyList(
         modifier = Modifier
             .fillMaxSize()
             .padding(bottom = 24.dp)
+            // Global touch handler for the drag gesture
             .pointerInput(Unit) {
                 detectDragGesturesAfterLongPress(
                     onDragStart = { offset ->
-                        // Identify item under finger
+                        // Hit test: Find which item index is under the finger
                         listState.layoutInfo.visibleItemsInfo
                             .firstOrNull { item -> offset.y.toInt() in item.offset..(item.offset + item.size) }
                             ?.let {
@@ -213,48 +246,43 @@ fun DraggableLazyList(
                         change.consume()
                         dragOffset += dragAmount.y
 
-                        // --- SMART SCROLL LOGIC ---
+                        // 1. Auto-Scroll Logic
                         val viewportHeight = listState.layoutInfo.viewportSize.height
                         val touchY = change.position.y
 
-                        // Check if we are in the Top Zone
-                        if (touchY < scrollThreshold) {
-                            // Only scroll UP if the user isn't actively dragging DOWN
-                            // and we aren't already at the top
-                            scrollVelocity = if (listState.canScrollBackward && dragAmount.y <= 0) -20f else 0f
-                        }
-                        // Check if we are in the Bottom Zone
-                        else if (touchY > viewportHeight - scrollThreshold) {
-                            // Only scroll DOWN if user isn't dragging UP
-                            // and we aren't already at the bottom
-                            scrollVelocity = if (listState.canScrollForward && dragAmount.y >= 0) 20f else 0f
+                        scrollVelocity = if (touchY < scrollThreshold) {
+                            // Scroll Up (Negative velocity) if allowed
+                            if (listState.canScrollBackward && dragAmount.y <= 0) -20f else 0f
+                        } else if (touchY > viewportHeight - scrollThreshold) {
+                            // Scroll Down (Positive velocity) if allowed
+                            if (listState.canScrollForward && dragAmount.y >= 0) 20f else 0f
                         } else {
-                            scrollVelocity = 0f
+                            0f
                         }
 
-                        // --- SWAP LOGIC ---
+                        // 2. Item Swap Logic
                         val currentIndex = draggingIndex ?: return@detectDragGesturesAfterLongPress
                         val currentItemInfo = listState.layoutInfo.visibleItemsInfo
                             .firstOrNull { it.index == currentIndex }
 
                         if (currentItemInfo != null) {
                             val itemHeight = currentItemInfo.size
-                            val threshold = itemHeight * 0.5f
+                            val threshold = itemHeight * 0.5f // Swap when overlapped 50%
 
-                            // Move Down
+                            // Dragging Down
                             if (dragOffset > threshold) {
                                 if (currentIndex < items.lastIndex) {
                                     onMove(currentIndex, currentIndex + 1)
                                     draggingIndex = currentIndex + 1
-                                    dragOffset -= itemHeight
+                                    dragOffset -= itemHeight // Compensate visual offset
                                 }
                             }
-                            // Move Up
+                            // Dragging Up
                             else if (dragOffset < -threshold) {
                                 if (currentIndex > 0) {
                                     onMove(currentIndex, currentIndex - 1)
                                     draggingIndex = currentIndex - 1
-                                    dragOffset += itemHeight
+                                    dragOffset += itemHeight // Compensate visual offset
                                 }
                             }
                         }
@@ -277,8 +305,9 @@ fun DraggableLazyList(
         itemsIndexed(items, key = { _, item -> item.packageName }) { index, item ->
 
             val isDragging = index == draggingIndex
-            // Visual Pop
-            val elevation by animateDpAsState(if (isDragging) 8.dp else 0.dp, label = "elevation")
+
+            // Visual Feedback: Lift up and scale
+            val elevation by animateDpAsState(if (isDragging) 12.dp else 0.dp, label = "elevation")
             val scale by animateFloatAsState(if (isDragging) 1.05f else 1f, label = "scale")
             val alpha = if (isDragging) 0.9f else 1f
 
@@ -286,7 +315,7 @@ fun DraggableLazyList(
 
             Box(
                 modifier = Modifier
-                    .zIndex(if (isDragging) 1f else 0f)
+                    .zIndex(if (isDragging) 1f else 0f) // Ensure dragged item is on top
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
@@ -294,7 +323,7 @@ fun DraggableLazyList(
                         translationY = if (isDragging) dragOffset else 0f
                     }
                     .shadow(elevation, RoundedCornerShape(12.dp))
-                    // Only animate items that are NOT being dragged
+                    // Only animate items shifting into place, NOT the item being dragged
                     .then(if (!isDragging) Modifier.animateItem() else Modifier)
             ) {
                 PriorityAppItem(
@@ -307,12 +336,14 @@ fun DraggableLazyList(
                         if (index > 0) {
                             onMove(index, index - 1)
                             onDragEnd()
+                            scope.launch { listState.animateScrollToItem(index - 1) }
                         }
                     },
                     onMoveDown = {
                         if (index < items.lastIndex) {
                             onMove(index, index + 1)
                             onDragEnd()
+                            scope.launch { listState.animateScrollToItem(index + 1) }
                         }
                     }
                 )
@@ -331,10 +362,29 @@ fun PriorityAppItem(
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit
 ) {
+    // Accessibility Strings
+    val moveUpLabel = stringResource(R.string.cd_move_up)
+    val moveDownLabel = stringResource(R.string.cd_move_down)
+    val handleDesc = stringResource(R.string.cd_drag_handle)
+    val appIconDesc = stringResource(R.string.cd_app_icon, app.name)
+
     val buttonTint = if (areButtonsEnabled) MaterialTheme.colorScheme.primary else Color.Transparent
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                // Accessibility Support for TalkBack users who cannot drag
+                stateDescription = "Priority $rank"
+                customActions = buildList {
+                    if (areButtonsEnabled && !isFirst) {
+                        add(CustomAccessibilityAction(label = moveUpLabel) { onMoveUp(); true })
+                    }
+                    if (areButtonsEnabled && !isLast) {
+                        add(CustomAccessibilityAction(label = moveDownLabel) { onMoveDown(); true })
+                    }
+                }
+            },
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
         shape = RoundedCornerShape(12.dp)
     ) {
@@ -342,14 +392,12 @@ fun PriorityAppItem(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Drag Handle (Visual)
+            // Visual Drag Handle
             Icon(
                 imageVector = Icons.Default.DragHandle,
-                contentDescription = null,
+                contentDescription = handleDesc,
                 tint = if (areButtonsEnabled) MaterialTheme.colorScheme.onSurfaceVariant else Color.Gray,
-                modifier = Modifier
-                    .size(48.dp)
-                    .padding(12.dp)
+                modifier = Modifier.size(48.dp).padding(12.dp)
             )
 
             Text(
@@ -360,7 +408,8 @@ fun PriorityAppItem(
                 modifier = Modifier.width(32.dp)
             )
 
-            AppIconLoader(packageName = app.packageName)
+            // Icon with Description
+            AppIconLoader(packageName = app.packageName, contentDescription = appIconDesc)
 
             Spacer(modifier = Modifier.width(12.dp))
 
@@ -371,35 +420,22 @@ fun PriorityAppItem(
                 fontWeight = FontWeight.SemiBold
             )
 
-            // Buttons (Transparent when dragging to keep layout stable)
-            IconButton(
-                onClick = onMoveUp,
-                modifier = Modifier.size(32.dp),
-                enabled = areButtonsEnabled && !isFirst
-            ) {
-                if (!isFirst) {
-                    Icon(Icons.Default.ArrowUpward, stringResource(R.string.move_up), tint = buttonTint, modifier = Modifier.size(20.dp))
-                }
+            // Manual Control Buttons (Hidden while dragging to prevent layout shifts)
+            IconButton(onClick = onMoveUp, modifier = Modifier.size(32.dp), enabled = areButtonsEnabled && !isFirst) {
+                if (!isFirst) Icon(Icons.Default.ArrowUpward, moveUpLabel, tint = buttonTint, modifier = Modifier.size(20.dp))
             }
-
-            IconButton(
-                onClick = onMoveDown,
-                modifier = Modifier.size(32.dp),
-                enabled = areButtonsEnabled && !isLast
-            ) {
-                if (!isLast) {
-                    Icon(Icons.Default.ArrowDownward, stringResource(R.string.move_down), tint = buttonTint, modifier = Modifier.size(20.dp))
-                }
+            IconButton(onClick = onMoveDown, modifier = Modifier.size(32.dp), enabled = areButtonsEnabled && !isLast) {
+                if (!isLast) Icon(Icons.Default.ArrowDownward, moveDownLabel, tint = buttonTint, modifier = Modifier.size(20.dp))
             }
-
             Spacer(Modifier.width(8.dp))
         }
     }
 }
 
 @Composable
-fun AppIconLoader(packageName: String) {
+fun AppIconLoader(packageName: String, contentDescription: String) {
     val context = LocalContext.current
+    // Remember bitmap so it doesn't reload on every recomposition
     var iconBitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
 
     LaunchedEffect(packageName) {
@@ -407,20 +443,20 @@ fun AppIconLoader(packageName: String) {
             try {
                 val drawable = context.packageManager.getApplicationIcon(packageName)
                 iconBitmap = drawable.toBitmap()
-            } catch (e: Exception) { }
+            } catch (e: Exception) { /* Ignore */ }
         }
     }
 
     if (iconBitmap != null) {
         Image(
             bitmap = iconBitmap!!.asImageBitmap(),
-            contentDescription = null,
+            contentDescription = contentDescription,
             modifier = Modifier.size(36.dp)
         )
     } else {
         Icon(
             imageVector = Icons.Default.Android,
-            contentDescription = null,
+            contentDescription = contentDescription,
             modifier = Modifier.size(36.dp),
             tint = MaterialTheme.colorScheme.surfaceVariant
         )

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/ChangelogHistoryScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/ChangelogHistoryScreen.kt
@@ -3,65 +3,34 @@ package com.d4viddf.hyperbridge.ui.screens.settings
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalIconButton
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.util.parseBold // Import shared extension
 
-// Data Model
-data class VersionLog(
-    val version: String,
-    val titleRes: Int,
-    val textRes: Int,
-    val isLatest: Boolean = false
-)
+data class VersionLog(val version: String, val titleRes: Int, val textRes: Int, val isLatest: Boolean = false)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChangelogHistoryScreen(onBack: () -> Unit) {
-    // History Data
+    // Define history here (Newest first)
+    // Note: 0.2.0 is latest RELEASED version. 0.3.0 is DEV.
     val history = listOf(
         VersionLog("0.2.0", R.string.title_0_2_0, R.string.changelog_0_2_0, isLatest = true),
         VersionLog("0.1.0", R.string.title_0_1_0, R.string.changelog_0_1_0)
@@ -104,21 +73,25 @@ fun ChangelogItem(log: VersionLog) {
 
     val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "rotation")
 
-    // Styling based on Latest status
+    // Dynamic Colors
     val cardColor = if (log.isLatest) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh
     val contentColor = if (log.isLatest) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
 
+    // Accessibility
+    val expandLabel = if (expanded) stringResource(R.string.cd_collapse_changelog) else stringResource(R.string.cd_expand_changelog)
+
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClickLabel = expandLabel) { expanded = !expanded },
         shape = RoundedCornerShape(20.dp),
-        colors = CardDefaults.cardColors(containerColor = cardColor),
-        onClick = { expanded = !expanded }
+        colors = CardDefaults.cardColors(containerColor = cardColor)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
 
-            // Header
+            // --- HEADER ---
             Row(verticalAlignment = Alignment.CenterVertically) {
-                // Version Number
+                // Version Bubble
                 Box(
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))
@@ -144,10 +117,10 @@ fun ChangelogItem(log: VersionLog) {
                     modifier = Modifier.weight(1f)
                 )
 
-                // --- CHANGED: TEXT BADGE ---
+                // "NEW" Badge
                 if (log.isLatest) {
                     Surface(
-                        color = MaterialTheme.colorScheme.primary, // Pop color
+                        color = MaterialTheme.colorScheme.primary,
                         shape = RoundedCornerShape(4.dp),
                         modifier = Modifier.padding(end = 8.dp)
                     ) {
@@ -160,9 +133,7 @@ fun ChangelogItem(log: VersionLog) {
                         )
                     }
                 }
-                // ---------------------------
 
-                // Arrow
                 Icon(
                     imageVector = Icons.Default.KeyboardArrowDown,
                     contentDescription = null,
@@ -171,13 +142,14 @@ fun ChangelogItem(log: VersionLog) {
                 )
             }
 
-            // Content
+            // --- CONTENT (BOLD PARSER) ---
             AnimatedVisibility(visible = expanded) {
                 Column {
                     Spacer(modifier = Modifier.height(12.dp))
                     HorizontalDivider(color = contentColor.copy(alpha = 0.2f))
                     Spacer(modifier = Modifier.height(12.dp))
 
+                    // Fix: Use parseBold()
                     Text(
                         text = stringResource(log.textRes).parseBold(),
                         style = MaterialTheme.typography.bodyMedium,
@@ -186,41 +158,6 @@ fun ChangelogItem(log: VersionLog) {
                     )
                 }
             }
-        }
-    }
-}
-
-/**
- * Robust helper to parse <b>text</b> into Bold SpanStyles using Regex.
- */
-@Composable
-fun String.parseBold(): androidx.compose.ui.text.AnnotatedString {
-    // 1. Fix newline escape characters often found in XML strings
-    val rawText = this.replace("\\n", "\n")
-
-    // 2. Use Regex to find content inside <b> tags
-    val boldRegex = Regex("<b>(.*?)</b>")
-
-    return buildAnnotatedString {
-        var lastIndex = 0
-
-        // Iterate over all matches
-        boldRegex.findAll(rawText).forEach { match ->
-            // Append normal text BEFORE the bold tag
-            append(rawText.substring(lastIndex, match.range.first))
-
-            // Append the BOLD content (Group 1 of the regex)
-            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-                append(match.groupValues[1])
-            }
-
-            // Move index past this match
-            lastIndex = match.range.last + 1
-        }
-
-        // Append any remaining normal text after the last match
-        if (lastIndex < rawText.length) {
-            append(rawText.substring(lastIndex))
         }
     }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/InfoScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/InfoScreen.kt
@@ -23,9 +23,12 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.util.parseBold // Import the shared extension
 import com.d4viddf.hyperbridge.util.toBitmap
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -36,16 +39,18 @@ fun InfoScreen(
     onLicensesClick: () -> Unit,
     onBehaviorClick: () -> Unit,
     onGlobalSettingsClick: () -> Unit,
-    onHistoryClick: () -> Unit // NEW
+    onHistoryClick: () -> Unit
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val scrollState = rememberScrollState()
 
+    // Safe Version Loading
     val appVersion = try {
         context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "1.0.0"
     } catch (e: Exception) { "1.0.0" }
 
+    // Safe Icon Loading
     val appIconBitmap = remember(context) {
         try { context.packageManager.getApplicationIcon(context.packageName).toBitmap().asImageBitmap() } catch (e: Exception) { null }
     }
@@ -76,7 +81,7 @@ fun InfoScreen(
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // --- HEADER ---
+            // --- APP HEADER ---
             Spacer(modifier = Modifier.height(16.dp))
 
             if (appIconBitmap != null) {
@@ -128,7 +133,7 @@ fun InfoScreen(
 
                 HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant.copy(0.5f))
 
-                // Island Behavior
+                // Island Behavior (Priority)
                 SettingsItem(
                     icon = Icons.Default.Tune,
                     title = stringResource(R.string.island_behavior),
@@ -162,11 +167,11 @@ fun InfoScreen(
 
                 HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant.copy(0.5f))
 
-                // Version History (NEW)
+                // Version History
                 SettingsItem(
                     icon = Icons.Default.History,
                     title = stringResource(R.string.version_history),
-                    subtitle = "0.1.0 - 0.2.0",
+                    subtitle = "0.1.0 - 0.3.0",
                     onClick = onHistoryClick
                 )
 
@@ -192,7 +197,14 @@ fun InfoScreen(
             }
 
             Spacer(modifier = Modifier.height(32.dp))
-            Text(stringResource(R.string.footer_made_with_love), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
+
+            // FOOTER (With Bold Parser Support)
+            Text(
+                text = stringResource(R.string.footer_made_with_love).parseBold(),
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.Gray
+            )
+
             Spacer(modifier = Modifier.height(16.dp))
         }
     }
@@ -204,7 +216,10 @@ fun SettingsGroupTitle(text: String) {
         text = text,
         style = MaterialTheme.typography.labelLarge,
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, start = 4.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp, start = 4.dp)
+            .semantics { heading() }
     )
 }
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/util/ComposeExtensions.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/util/ComposeExtensions.kt
@@ -1,0 +1,44 @@
+package com.d4viddf.hyperbridge.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+
+/**
+ * Reusable helper to parse &lt;b&gt;text&lt;/b&gt; tags from strings.xml into Bold SpanStyles.
+ * Used for Changelogs, Credits, and Info screens.
+ */
+@Composable
+fun String.parseBold(): androidx.compose.ui.text.AnnotatedString {
+    // 1. Fix newline escape characters from XML
+    val rawText = this.replace("\\n", "\n")
+
+    // 2. Regex to match &lt;b&gt;content&lt;/b&gt; (XML escaped tags)
+    // We also check for standard <b> just in case.
+    val boldRegex = Regex("(&lt;b&gt;|<b>)(.*?)(&lt;/b&gt;|</b>)")
+
+    return buildAnnotatedString {
+        var lastIndex = 0
+
+        boldRegex.findAll(rawText).forEach { match ->
+            // Append normal text BEFORE the tag
+            append(rawText.substring(lastIndex, match.range.first))
+
+            // Append the content inside tags as BOLD
+            // groupValues[2] contains the text inside the tags
+            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                append(match.groupValues[2])
+            }
+
+            // Move index past this match
+            lastIndex = match.range.last + 1
+        }
+
+        // Append any remaining normal text
+        if (lastIndex < rawText.length) {
+            append(rawText.substring(lastIndex))
+        }
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -224,4 +224,16 @@
     <string name="nav_content_none">Vacío</string>
 
     <string name="channel_active_islands">Islas Activas</string>
+
+    <string name="cd_toggle_app">Alternar %s</string>
+    <string name="cd_configure_app">Configurar %s</string>
+    <string name="cd_enable_type">Activar notificaciones de %s</string>
+    <string name="cd_disable_type">Desactivar notificaciones de %s</string>
+    <string name="cd_nav_edit">Editar diseño de navegación</string>
+    <string name="cd_app_state_active">Activo</string>
+    <string name="cd_app_state_inactive">Inactivo</string>
+
+    <string name="nav_preview_instruction">Girar a la derecha</string>
+    <string name="nav_preview_distance">200m</string>
+    <string name="nav_preview_time">10:30</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,4 +219,26 @@
     <string name="nav_content_none">Empty</string>
 
     <string name="channel_active_islands">Active Islands</string>
+
+    <string name="cd_toggle_app">Toggle %s</string>
+    <string name="cd_configure_app">Configure %s</string>
+    <string name="cd_enable_type">Enable %s notifications</string>
+    <string name="cd_disable_type">Disable %s notifications</string>
+    <string name="cd_nav_edit">Edit navigation layout</string>
+    <string name="cd_app_state_active">Active</string>
+    <string name="cd_app_state_inactive">Inactive</string>
+
+    <string name="cd_move_up">Move item up</string>
+    <string name="cd_move_down">Move item down</string>
+    <string name="cd_drag_handle">Drag handle. Double tap and hold to reorder, or use actions to move.</string>
+    <string name="cd_app_icon">App Icon for %s</string>
+    <string name="cd_nav_preview">Navigation Preview: %1$s on left, %2$s on right</string>
+    <string name="cd_expand_changelog">Expand version details</string>
+    <string name="cd_collapse_changelog">Collapse version details</string>
+    <string name="cd_configuration_group">Configuration Settings</string>
+    <string name="cd_about_group">About Information</string>
+
+    <string name="nav_preview_instruction">Turn Right</string>
+    <string name="nav_preview_distance">200m</string>
+    <string name="nav_preview_time">10:30</string>
 </resources>


### PR DESCRIPTION
- Implemented custom accessibility actions for the App Priority List (Move Up/Down) to allow reordering without drag gestures.
- Added dynamic content descriptions to App List switches and buttons (e.g., "Toggle [App Name]" instead of just "Switch").
- Marked settings group titles as Semantic Headings for faster screen reader navigation.
- Added state descriptions to the Navigation Layout Preview to describe the current configuration audibly.
- Improved labeling for expand/collapse actions in the Version History screen.
- Fixed missing content descriptions on navigation and edit icon buttons.

Closed #17