### PR TITLE
fix(deps): downgrade DataStore to resolve boot persistence issues

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         tools:ignore="QueryAllPackagesPermission" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/d4viddf/hyperbridge/MainActivity.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/MainActivity.kt
@@ -43,10 +43,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             HyperBridgeTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
                     MainRootNavigation()
                 }
             }
@@ -55,16 +52,7 @@ class MainActivity : ComponentActivity() {
 }
 
 enum class Screen(val depth: Int) {
-    ONBOARDING(0),
-    HOME(1),
-    INFO(2),
-    SETUP(3),
-    LICENSES(3),
-    BEHAVIOR(3),
-    GLOBAL_SETTINGS(3),
-    HISTORY(3),
-    NAV_CUSTOMIZATION(4),
-    APP_PRIORITY(4)
+    ONBOARDING(0), HOME(1), INFO(2), SETUP(3), LICENSES(3), BEHAVIOR(3), GLOBAL_SETTINGS(3), HISTORY(3), NAV_CUSTOMIZATION(4), APP_PRIORITY(4)
 }
 
 @Composable
@@ -76,40 +64,45 @@ fun MainRootNavigation() {
     val packageInfo = remember { try { context.packageManager.getPackageInfo(context.packageName, 0) } catch (e: Exception) { null } }
     @Suppress("DEPRECATION")
     val currentVersionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) packageInfo?.longVersionCode?.toInt() ?: 0 else packageInfo?.versionCode ?: 0
-    val currentVersionName = packageInfo?.versionName ?: "0.1.0"
+    val currentVersionName = packageInfo?.versionName ?: "0.2.0"
 
-    val isSetupComplete by preferences.isSetupComplete.collectAsState(initial = null)
+    // 1. COLLECT DATA
+    // Use a separate state to track if data has loaded at least once
+    var isDataLoaded by remember { mutableStateOf(false) }
+
+    val isSetupComplete by preferences.isSetupComplete.collectAsState(initial = false)
     val lastSeenVersion by preferences.lastSeenVersion.collectAsState(initial = currentVersionCode)
     val isPriorityEduShown by preferences.isPriorityEduShown.collectAsState(initial = true)
+
+    // Hack: Use a side-effect to know when the first valid emission has happened
+    LaunchedEffect(Unit) {
+        preferences.isSetupComplete.collect { isDataLoaded = true }
+    }
 
     var currentScreen by remember { mutableStateOf<Screen?>(null) }
     var showChangelog by remember { mutableStateOf(false) }
     var showPriorityEdu by remember { mutableStateOf(false) }
-
-    // Track which app is being edited for Nav Layout (null = Global)
     var navConfigPackage by remember { mutableStateOf<String?>(null) }
 
-    LaunchedEffect(isSetupComplete, lastSeenVersion, isPriorityEduShown) {
-        if (isSetupComplete == false) {
-            currentScreen = Screen.ONBOARDING
-        } else if (isSetupComplete == true && currentScreen == null) {
-            currentScreen = Screen.HOME
-        }
+    // 2. ROUTING
+    LaunchedEffect(isDataLoaded, isSetupComplete) {
+        if (isDataLoaded) {
+            if (currentScreen == null) {
+                currentScreen = if (isSetupComplete) Screen.HOME else Screen.ONBOARDING
+            }
 
-        if (isSetupComplete == true && currentVersionCode > lastSeenVersion) {
-            showChangelog = true
-        } else if (isSetupComplete == true && !isPriorityEduShown && !showChangelog) {
-            showPriorityEdu = true
+            // Modals check
+            if (isSetupComplete) {
+                if (currentVersionCode > lastSeenVersion) showChangelog = true
+                else if (!isPriorityEduShown && !showChangelog) showPriorityEdu = true
+            }
         }
     }
 
-    // Back Logic
+    // 3. BACK LOGIC
     BackHandler(enabled = currentScreen != Screen.HOME && currentScreen != Screen.ONBOARDING) {
         currentScreen = when (currentScreen) {
-            Screen.NAV_CUSTOMIZATION -> {
-                // If editing specific app, go back to Home. If global, go back to Global Settings.
-                if (navConfigPackage != null) Screen.HOME else Screen.GLOBAL_SETTINGS
-            }
+            Screen.NAV_CUSTOMIZATION -> if (navConfigPackage != null) Screen.HOME else Screen.GLOBAL_SETTINGS
             Screen.GLOBAL_SETTINGS -> Screen.INFO
             Screen.APP_PRIORITY -> Screen.BEHAVIOR
             Screen.HISTORY -> Screen.INFO
@@ -119,7 +112,8 @@ fun MainRootNavigation() {
         }
     }
 
-    if (currentScreen == null) {
+    // 4. RENDER
+    if (!isDataLoaded || currentScreen == null) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
     } else {
         AnimatedContent(
@@ -144,10 +138,7 @@ fun MainRootNavigation() {
                 }
                 Screen.HOME -> HomeScreen(
                     onSettingsClick = { currentScreen = Screen.INFO },
-                    onNavConfigClick = { pkg ->
-                        navConfigPackage = pkg
-                        currentScreen = Screen.NAV_CUSTOMIZATION
-                    }
+                    onNavConfigClick = { pkg -> navConfigPackage = pkg; currentScreen = Screen.NAV_CUSTOMIZATION }
                 )
                 Screen.INFO -> InfoScreen(
                     onBack = { currentScreen = Screen.HOME },
@@ -157,25 +148,11 @@ fun MainRootNavigation() {
                     onGlobalSettingsClick = { currentScreen = Screen.GLOBAL_SETTINGS },
                     onHistoryClick = { currentScreen = Screen.HISTORY }
                 )
-                Screen.GLOBAL_SETTINGS -> GlobalSettingsScreen(
-                    onBack = { currentScreen = Screen.INFO },
-                    onNavSettingsClick = {
-                        navConfigPackage = null // Global Mode
-                        currentScreen = Screen.NAV_CUSTOMIZATION
-                    }
-                )
-                Screen.NAV_CUSTOMIZATION -> NavCustomizationScreen(
-                    onBack = {
-                        currentScreen = if (navConfigPackage != null) Screen.HOME else Screen.GLOBAL_SETTINGS
-                    },
-                    packageName = navConfigPackage
-                )
+                Screen.GLOBAL_SETTINGS -> GlobalSettingsScreen(onBack = { currentScreen = Screen.INFO }, onNavSettingsClick = { navConfigPackage = null; currentScreen = Screen.NAV_CUSTOMIZATION })
+                Screen.NAV_CUSTOMIZATION -> NavCustomizationScreen(onBack = { currentScreen = if (navConfigPackage != null) Screen.HOME else Screen.GLOBAL_SETTINGS }, packageName = navConfigPackage)
                 Screen.SETUP -> SetupHealthScreen(onBack = { currentScreen = Screen.INFO })
                 Screen.LICENSES -> LicensesScreen(onBack = { currentScreen = Screen.INFO })
-                Screen.BEHAVIOR -> PrioritySettingsScreen(
-                    onBack = { currentScreen = Screen.INFO },
-                    onNavigateToPriorityList = { currentScreen = Screen.APP_PRIORITY }
-                )
+                Screen.BEHAVIOR -> PrioritySettingsScreen(onBack = { currentScreen = Screen.INFO }, onNavigateToPriorityList = { currentScreen = Screen.APP_PRIORITY })
                 Screen.APP_PRIORITY -> AppPriorityScreen(onBack = { currentScreen = Screen.BEHAVIOR })
                 Screen.HISTORY -> ChangelogHistoryScreen(onBack = { currentScreen = Screen.INFO })
             }

--- a/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
@@ -1,98 +1,110 @@
 package com.d4viddf.hyperbridge.data
 
 import android.content.Context
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.core.stringSetPreferencesKey
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
 import com.d4viddf.hyperbridge.models.IslandConfig
 import com.d4viddf.hyperbridge.models.IslandLimitMode
 import com.d4viddf.hyperbridge.models.NavContent
 import com.d4viddf.hyperbridge.models.NotificationType
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 
-val Context.dataStore by preferencesDataStore(name = "settings")
+// 1. SINGLETON DATASTORE SETUP
+// Using a private extension on Context that we invoke on applicationContext ensures valid singleton behavior.
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
-class AppPreferences(private val context: Context) {
+class AppPreferences(context: Context) {
+
+    // Ensure we always use Application Context to avoid memory leaks and context mismatches
+    private val dataStore = context.applicationContext.dataStore
 
     companion object {
-        // Core
+        // Keys
         private val ALLOWED_PACKAGES_KEY = stringSetPreferencesKey("allowed_packages")
         private val SETUP_COMPLETE_KEY = booleanPreferencesKey("setup_complete")
         private val LAST_VERSION_CODE_KEY = intPreferencesKey("last_version_code")
         private val PRIORITY_EDU_KEY = booleanPreferencesKey("priority_edu_shown")
-
-        // Limits
         private val LIMIT_MODE_KEY = stringPreferencesKey("limit_mode")
         private val PRIORITY_ORDER_KEY = stringPreferencesKey("priority_app_order")
-
-        // Global Appearance
         private val GLOBAL_FLOAT_KEY = booleanPreferencesKey("global_float")
         private val GLOBAL_SHADE_KEY = booleanPreferencesKey("global_shade")
         private val GLOBAL_TIMEOUT_KEY = longPreferencesKey("global_timeout")
-
-        // Global Navigation
         private val NAV_LEFT_CONTENT_KEY = stringPreferencesKey("nav_left_content")
         private val NAV_RIGHT_CONTENT_KEY = stringPreferencesKey("nav_right_content")
     }
 
-    // --- CORE ---
-    val allowedPackagesFlow: Flow<Set<String>> = context.dataStore.data.map { it[ALLOWED_PACKAGES_KEY] ?: emptySet() }
-    val isSetupComplete: Flow<Boolean> = context.dataStore.data.map { it[SETUP_COMPLETE_KEY] ?: false }
-    val lastSeenVersion: Flow<Int> = context.dataStore.data.map { it[LAST_VERSION_CODE_KEY] ?: 0 }
-    val isPriorityEduShown: Flow<Boolean> = context.dataStore.data.map { it[PRIORITY_EDU_KEY] ?: false }
+    // Helper to catch IOExceptions (e.g. during boot or file corruption)
+    private val safeData: Flow<Preferences> = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                Log.e("AppPreferences", "Error reading preferences", exception)
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
 
-    suspend fun setSetupComplete(isComplete: Boolean) { context.dataStore.edit { it[SETUP_COMPLETE_KEY] = isComplete } }
-    suspend fun setLastSeenVersion(versionCode: Int) { context.dataStore.edit { it[LAST_VERSION_CODE_KEY] = versionCode } }
-    suspend fun setPriorityEduShown(shown: Boolean) { context.dataStore.edit { it[PRIORITY_EDU_KEY] = shown } }
+    // --- CORE ---
+    val allowedPackagesFlow: Flow<Set<String>> = safeData.map { it[ALLOWED_PACKAGES_KEY] ?: emptySet() }
+
+    // FIX: Returns FALSE by default (First Install), never null.
+    val isSetupComplete: Flow<Boolean> = safeData.map { it[SETUP_COMPLETE_KEY] ?: false }
+
+    val lastSeenVersion: Flow<Int> = safeData.map { it[LAST_VERSION_CODE_KEY] ?: 0 }
+    val isPriorityEduShown: Flow<Boolean> = safeData.map { it[PRIORITY_EDU_KEY] ?: false }
+
+    suspend fun setSetupComplete(isComplete: Boolean) { dataStore.edit { it[SETUP_COMPLETE_KEY] = isComplete } }
+    suspend fun setLastSeenVersion(versionCode: Int) { dataStore.edit { it[LAST_VERSION_CODE_KEY] = versionCode } }
+    suspend fun setPriorityEduShown(shown: Boolean) { dataStore.edit { it[PRIORITY_EDU_KEY] = shown } }
 
     suspend fun toggleApp(packageName: String, isEnabled: Boolean) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             val current = prefs[ALLOWED_PACKAGES_KEY] ?: emptySet()
             prefs[ALLOWED_PACKAGES_KEY] = if (isEnabled) current + packageName else current - packageName
         }
     }
 
     // --- LIMITS ---
-    val limitModeFlow: Flow<IslandLimitMode> = context.dataStore.data.map {
+    val limitModeFlow: Flow<IslandLimitMode> = safeData.map {
         try { IslandLimitMode.valueOf(it[LIMIT_MODE_KEY] ?: IslandLimitMode.MOST_RECENT.name) } catch(e: Exception) { IslandLimitMode.MOST_RECENT }
     }
-    val appPriorityListFlow: Flow<List<String>> = context.dataStore.data.map { it[PRIORITY_ORDER_KEY]?.split(",") ?: emptyList() }
+    val appPriorityListFlow: Flow<List<String>> = safeData.map { it[PRIORITY_ORDER_KEY]?.split(",") ?: emptyList() }
 
-    suspend fun setLimitMode(mode: IslandLimitMode) { context.dataStore.edit { it[LIMIT_MODE_KEY] = mode.name } }
-    suspend fun setAppPriorityOrder(order: List<String>) { context.dataStore.edit { it[PRIORITY_ORDER_KEY] = order.joinToString(",") } }
+    suspend fun setLimitMode(mode: IslandLimitMode) { dataStore.edit { it[LIMIT_MODE_KEY] = mode.name } }
+    suspend fun setAppPriorityOrder(order: List<String>) { dataStore.edit { it[PRIORITY_ORDER_KEY] = order.joinToString(",") } }
 
     // --- TYPE CONFIG ---
     fun getAppConfig(packageName: String): Flow<Set<String>> {
         val key = stringSetPreferencesKey("config_$packageName")
-        return context.dataStore.data.map { it[key] ?: NotificationType.entries.map { t -> t.name }.toSet() }
+        return safeData.map { it[key] ?: NotificationType.entries.map { t -> t.name }.toSet() }
     }
     suspend fun updateAppConfig(packageName: String, type: NotificationType, isEnabled: Boolean) {
         val key = stringSetPreferencesKey("config_$packageName")
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             val current = prefs[key] ?: NotificationType.entries.map { it.name }.toSet()
             prefs[key] = if (isEnabled) current + type.name else current - type.name
         }
     }
 
     // --- ISLAND CONFIG ---
-    val globalConfigFlow: Flow<IslandConfig> = context.dataStore.data.map {
+    val globalConfigFlow: Flow<IslandConfig> = safeData.map {
         IslandConfig(it[GLOBAL_FLOAT_KEY] ?: true, it[GLOBAL_SHADE_KEY] ?: true, it[GLOBAL_TIMEOUT_KEY] ?: 5000L)
     }
     suspend fun updateGlobalConfig(config: IslandConfig) {
-        context.dataStore.edit {
+        dataStore.edit {
             config.isFloat?.let { v -> it[GLOBAL_FLOAT_KEY] = v }
             config.isShowShade?.let { v -> it[GLOBAL_SHADE_KEY] = v }
             config.timeout?.let { v -> it[GLOBAL_TIMEOUT_KEY] = v }
         }
     }
     fun getAppIslandConfig(packageName: String): Flow<IslandConfig> {
-        return context.dataStore.data.map {
+        return safeData.map {
             IslandConfig(
                 it[booleanPreferencesKey("config_${packageName}_float")],
                 it[booleanPreferencesKey("config_${packageName}_shade")],
@@ -101,7 +113,7 @@ class AppPreferences(private val context: Context) {
         }
     }
     suspend fun updateAppIslandConfig(packageName: String, config: IslandConfig) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             val f = booleanPreferencesKey("config_${packageName}_float")
             val s = booleanPreferencesKey("config_${packageName}_shade")
             val t = longPreferencesKey("config_${packageName}_timeout")
@@ -112,23 +124,21 @@ class AppPreferences(private val context: Context) {
     }
 
     // --- NAVIGATION LAYOUT ---
-
-    val globalNavLayoutFlow: Flow<Pair<NavContent, NavContent>> = context.dataStore.data.map { prefs ->
+    val globalNavLayoutFlow: Flow<Pair<NavContent, NavContent>> = safeData.map { prefs ->
         val left = try { NavContent.valueOf(prefs[NAV_LEFT_CONTENT_KEY] ?: NavContent.DISTANCE_ETA.name) } catch (e: Exception) { NavContent.DISTANCE_ETA }
         val right = try { NavContent.valueOf(prefs[NAV_RIGHT_CONTENT_KEY] ?: NavContent.INSTRUCTION.name) } catch (e: Exception) { NavContent.INSTRUCTION }
         left to right
     }
 
     suspend fun setGlobalNavLayout(left: NavContent, right: NavContent) {
-        context.dataStore.edit {
+        dataStore.edit {
             it[NAV_LEFT_CONTENT_KEY] = left.name
             it[NAV_RIGHT_CONTENT_KEY] = right.name
         }
     }
 
-    // Per-App Overrides (Returns null if not set)
     fun getAppNavLayout(packageName: String): Flow<Pair<NavContent?, NavContent?>> {
-        return context.dataStore.data.map { prefs ->
+        return safeData.map { prefs ->
             val lKey = stringPreferencesKey("config_${packageName}_nav_left")
             val rKey = stringPreferencesKey("config_${packageName}_nav_right")
             val l = prefs[lKey]?.let { try { NavContent.valueOf(it) } catch(e: Exception){null} }
@@ -137,7 +147,6 @@ class AppPreferences(private val context: Context) {
         }
     }
 
-    // Merged Effective Layout (App > Global)
     fun getEffectiveNavLayout(packageName: String): Flow<Pair<NavContent, NavContent>> {
         return combine(getAppNavLayout(packageName), globalNavLayoutFlow) { app, global ->
             (app.first ?: global.first) to (app.second ?: global.second)
@@ -145,7 +154,7 @@ class AppPreferences(private val context: Context) {
     }
 
     suspend fun updateAppNavLayout(packageName: String, left: NavContent?, right: NavContent?) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             val lKey = stringPreferencesKey("config_${packageName}_nav_left")
             val rKey = stringPreferencesKey("config_${packageName}_nav_right")
             if (left != null) prefs[lKey] = left.name else prefs.remove(lKey)

--- a/app/src/main/java/com/d4viddf/hyperbridge/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/receiver/BootReceiver.kt
@@ -10,7 +10,10 @@ import com.d4viddf.hyperbridge.service.NotificationReaderService
 
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+        // Check for both standard boot and quick boot (some ROMs use quick)
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED ||
+            intent.action == "android.intent.action.QUICKBOOT_POWERON") {
+
             Log.d("HyperBridge", "Boot completed detected.")
 
             // Trick: We toggle the component state to force the Notification Manager

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.1"
-datastorePreferences = "1.2.0"
+datastorePreferences = "1.1.7"
 hyperislandKit = "0.3.0"
 kotlin = "2.2.21"
 coreKtx = "1.17.0"


### PR DESCRIPTION
- Downgraded `androidx.datastore:datastore-preferences` from 1.2.0 to 1.1.7.
- The 1.2.0 update introduced a regression on HyperOS/MIUI devices where preference files were not readable immediately after boot, causing the app to reset to the Onboarding screen and lose saved configurations.
- Reverting to the stable 1.1.x release restores reliable data persistence across reboots.

Closes #5