### PR TITLE
feat(blocklist): add spoiler and privacy protection and redesign conf…

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/MainActivity.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/MainActivity.kt
@@ -4,14 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -27,14 +21,7 @@ import com.d4viddf.hyperbridge.ui.components.ChangelogDialog
 import com.d4viddf.hyperbridge.ui.components.PriorityEducationDialog
 import com.d4viddf.hyperbridge.ui.screens.home.HomeScreen
 import com.d4viddf.hyperbridge.ui.screens.onboarding.OnboardingScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.AppPriorityScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.ChangelogHistoryScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.GlobalSettingsScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.InfoScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.LicensesScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.NavCustomizationScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.PrioritySettingsScreen
-import com.d4viddf.hyperbridge.ui.screens.settings.SetupHealthScreen
+import com.d4viddf.hyperbridge.ui.screens.settings.*
 import com.d4viddf.hyperbridge.ui.theme.HyperBridgeTheme
 import kotlinx.coroutines.launch
 
@@ -52,7 +39,8 @@ class MainActivity : ComponentActivity() {
 }
 
 enum class Screen(val depth: Int) {
-    ONBOARDING(0), HOME(1), INFO(2), SETUP(3), LICENSES(3), BEHAVIOR(3), GLOBAL_SETTINGS(3), HISTORY(3), NAV_CUSTOMIZATION(4), APP_PRIORITY(4)
+    ONBOARDING(0), HOME(1), INFO(2), SETUP(3), LICENSES(3), BEHAVIOR(3), GLOBAL_SETTINGS(3), HISTORY(3), NAV_CUSTOMIZATION(4), APP_PRIORITY(4), GLOBAL_BLOCKLIST(4),
+    BLOCKLIST_APPS(5)
 }
 
 @Composable
@@ -66,40 +54,41 @@ fun MainRootNavigation() {
     val currentVersionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) packageInfo?.longVersionCode?.toInt() ?: 0 else packageInfo?.versionCode ?: 0
     val currentVersionName = packageInfo?.versionName ?: "0.2.0"
 
-    // 1. COLLECT DATA
-    // Use a separate state to track if data has loaded at least once
-    var isDataLoaded by remember { mutableStateOf(false) }
+    // --- 1. ROBUST DATA COLLECTION ---
+    // We use produceState to initialize as NULL.
+    // This ensures we show the Loading Spinner until the Flow emits its first real value from disk.
+    val isSetupComplete by produceState<Boolean?>(initialValue = null) {
+        preferences.isSetupComplete.collect { value = it }
+    }
 
-    val isSetupComplete by preferences.isSetupComplete.collectAsState(initial = false)
     val lastSeenVersion by preferences.lastSeenVersion.collectAsState(initial = currentVersionCode)
     val isPriorityEduShown by preferences.isPriorityEduShown.collectAsState(initial = true)
-
-    // Hack: Use a side-effect to know when the first valid emission has happened
-    LaunchedEffect(Unit) {
-        preferences.isSetupComplete.collect { isDataLoaded = true }
-    }
 
     var currentScreen by remember { mutableStateOf<Screen?>(null) }
     var showChangelog by remember { mutableStateOf(false) }
     var showPriorityEdu by remember { mutableStateOf(false) }
     var navConfigPackage by remember { mutableStateOf<String?>(null) }
 
-    // 2. ROUTING
-    LaunchedEffect(isDataLoaded, isSetupComplete) {
-        if (isDataLoaded) {
+    // --- 2. ROUTING LOGIC ---
+    LaunchedEffect(isSetupComplete) {
+        // Only run logic when we have a valid boolean from disk
+        if (isSetupComplete != null) {
             if (currentScreen == null) {
-                currentScreen = if (isSetupComplete) Screen.HOME else Screen.ONBOARDING
+                // Route based on saved state
+                currentScreen = if (isSetupComplete == true) Screen.HOME else Screen.ONBOARDING
             }
 
-            // Modals check
-            if (isSetupComplete) {
-                if (currentVersionCode > lastSeenVersion) showChangelog = true
-                else if (!isPriorityEduShown && !showChangelog) showPriorityEdu = true
+            // If setup is done, check for modals
+            if (isSetupComplete == true) {
+                if (currentVersionCode > lastSeenVersion) {
+                    showChangelog = true
+                } else if (!isPriorityEduShown && !showChangelog) {
+                    showPriorityEdu = true
+                }
             }
         }
     }
 
-    // 3. BACK LOGIC
     BackHandler(enabled = currentScreen != Screen.HOME && currentScreen != Screen.ONBOARDING) {
         currentScreen = when (currentScreen) {
             Screen.NAV_CUSTOMIZATION -> if (navConfigPackage != null) Screen.HOME else Screen.GLOBAL_SETTINGS
@@ -112,9 +101,12 @@ fun MainRootNavigation() {
         }
     }
 
-    // 4. RENDER
-    if (!isDataLoaded || currentScreen == null) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+    // --- 3. LOADING STATE ---
+    // If setup state is null, or we haven't routed yet -> Show Spinner
+    if (isSetupComplete == null || currentScreen == null) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
     } else {
         AnimatedContent(
             targetState = currentScreen!!,
@@ -146,7 +138,8 @@ fun MainRootNavigation() {
                     onLicensesClick = { currentScreen = Screen.LICENSES },
                     onBehaviorClick = { currentScreen = Screen.BEHAVIOR },
                     onGlobalSettingsClick = { currentScreen = Screen.GLOBAL_SETTINGS },
-                    onHistoryClick = { currentScreen = Screen.HISTORY }
+                    onHistoryClick = { currentScreen = Screen.HISTORY },
+                    onBlocklistClick = { currentScreen = Screen.GLOBAL_BLOCKLIST }
                 )
                 Screen.GLOBAL_SETTINGS -> GlobalSettingsScreen(onBack = { currentScreen = Screen.INFO }, onNavSettingsClick = { navConfigPackage = null; currentScreen = Screen.NAV_CUSTOMIZATION })
                 Screen.NAV_CUSTOMIZATION -> NavCustomizationScreen(onBack = { currentScreen = if (navConfigPackage != null) Screen.HOME else Screen.GLOBAL_SETTINGS }, packageName = navConfigPackage)
@@ -155,6 +148,14 @@ fun MainRootNavigation() {
                 Screen.BEHAVIOR -> PrioritySettingsScreen(onBack = { currentScreen = Screen.INFO }, onNavigateToPriorityList = { currentScreen = Screen.APP_PRIORITY })
                 Screen.APP_PRIORITY -> AppPriorityScreen(onBack = { currentScreen = Screen.BEHAVIOR })
                 Screen.HISTORY -> ChangelogHistoryScreen(onBack = { currentScreen = Screen.INFO })
+                Screen.GLOBAL_BLOCKLIST -> GlobalBlocklistScreen(
+                    onBack = { currentScreen = Screen.INFO },
+                    onNavigateToAppList = { currentScreen = Screen.BLOCKLIST_APPS }
+                )
+
+                Screen.BLOCKLIST_APPS -> BlocklistAppListScreen(
+                    onBack = { currentScreen = Screen.GLOBAL_BLOCKLIST }
+                )
             }
         }
     }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/AppListViewModel.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/AppListViewModel.kt
@@ -109,8 +109,7 @@ class AppListViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch { preferences.updateAppConfig(pkg, type, enabled) }
     }
 
-    // --- NEW: ISLAND APPEARANCE BRIDGES ---
-
+    // --- ISLAND APPEARANCE BRIDGES ---
     val globalConfigFlow = preferences.globalConfigFlow
 
     fun getAppIslandConfig(packageName: String) = preferences.getAppIslandConfig(packageName)
@@ -122,12 +121,25 @@ class AppListViewModel(application: Application) : AndroidViewModel(application)
     fun updateGlobalConfig(config: IslandConfig) {
         viewModelScope.launch { preferences.updateGlobalConfig(config) }
     }
-    // --------------------------------------
+
+    // --- BLOCKED TERMS (FIX FOR ISSUE #6) ---
+    val globalBlockedTermsFlow = preferences.globalBlockedTermsFlow
+
+    fun setGlobalBlockedTerms(terms: Set<String>) {
+        viewModelScope.launch { preferences.setGlobalBlockedTerms(terms) }
+    }
+
+    fun getAppBlockedTerms(packageName: String) = preferences.getAppBlockedTerms(packageName)
+
+    fun updateAppBlockedTerms(packageName: String, terms: Set<String>) {
+        viewModelScope.launch { preferences.setAppBlockedTerms(packageName, terms) }
+    }
+    // ----------------------------------------
 
     // UI State Setters
-    fun setCategory(cat: AppCategory) { /* handled by state flows directly in UI for now, but keeping for compatibility */ }
-    fun setSort(option: SortOption) { /* same */ }
-    fun clearSearch() { /* same */ }
+    fun setCategory(cat: AppCategory) { }
+    fun setSort(option: SortOption) { }
+    fun clearSearch() { }
 
     // App Loader
     private suspend fun getLaunchableApps(): List<AppInfo> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/BlockListEditor.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/BlockListEditor.kt
@@ -1,0 +1,128 @@
+package com.d4viddf.hyperbridge.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.d4viddf.hyperbridge.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BlocklistEditor(
+    terms: Set<String>,
+    onUpdate: (Set<String>) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var text by remember { mutableStateOf("") }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Column(modifier = modifier) {
+        // Header
+        Row(verticalAlignment = Alignment.CenterVertically) {
+
+            Text(
+                text = stringResource(R.string.blocked_terms),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        Text(
+            text = stringResource(R.string.blocked_terms_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.Gray,
+            modifier = Modifier.padding( bottom = 12.dp)
+        )
+
+        // Input
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text(stringResource(R.string.add_blocked_word)) },
+            trailingIcon = {
+                IconButton(
+                    onClick = {
+                        if (text.isNotBlank()) {
+                            onUpdate(terms + text.trim())
+                            text = ""
+                        }
+                    }
+                ) {
+                    Icon(Icons.Default.Add, stringResource(R.string.add))
+                }
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = {
+                if (text.isNotBlank()) {
+                    onUpdate(terms + text.trim())
+                    text = ""
+                    keyboardController?.hide()
+                }
+            }),
+            shape = RoundedCornerShape(12.dp)
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        // Chips List
+        if (terms.isNotEmpty()) {
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                items(terms.toList()) { term ->
+                    InputChip(
+                        selected = true,
+                        onClick = { },
+                        label = { Text(term) },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Close,
+                                stringResource(R.string.remove),
+                                Modifier.size(16.dp).clickable { onUpdate(terms - term) }
+                            )
+                        },
+                        colors = InputChipDefaults.inputChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.errorContainer,
+                            selectedLabelColor = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/Dialogs.kt
@@ -1,18 +1,57 @@
 package com.d4viddf.hyperbridge.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -33,198 +72,275 @@ fun AppConfigBottomSheet(
     onDismiss: () -> Unit,
     onNavConfigClick: () -> Unit
 ) {
-    // Load states from ViewModel
+    // Data Loading
     val typeConfig by viewModel.getAppConfig(app.packageName).collectAsState(initial = emptySet())
     val appIslandConfig by viewModel.getAppIslandConfig(app.packageName).collectAsState(initial = IslandConfig())
     val globalConfig by viewModel.globalConfigFlow.collectAsState(initial = IslandConfig(true, true, 5000L))
+    val blockedTerms by viewModel.getAppBlockedTerms(app.packageName).collectAsState(initial = emptySet())
 
-    val sheetState = rememberModalBottomSheetState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val navEditDesc = stringResource(R.string.cd_nav_edit)
+    val activeDesc = stringResource(R.string.cd_app_state_active)
+    val inactiveDesc = stringResource(R.string.cd_app_state_inactive)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 48.dp) // Extra bottom padding for navigation bar safety
+                .padding(bottom = 4.dp)
         ) {
-            // =====================================================================
-            // HEADER: App Icon and Name
-            // =====================================================================
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(bottom = 24.dp)
+
+            // --- SCROLLABLE CONTENT ---
+            Column(
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp)
             ) {
-                Image(
-                    bitmap = app.icon.asImageBitmap(),
-                    contentDescription = null, // Decorative: Text name is sufficient for TalkBack
-                    modifier = Modifier.size(48.dp)
-                )
-                Spacer(modifier = Modifier.width(16.dp))
-                Column {
-                    Text(
-                        text = app.name,
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold
+                // HEADER
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(bottom = 24.dp)
+                ) {
+                    Image(
+                        bitmap = app.icon.asImageBitmap(),
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp).clip(RoundedCornerShape(12.dp))
                     )
-                    Text(
-                        text = stringResource(R.string.configure),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color.Gray
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Column {
+                        Text(app.name, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                        Text(app.packageName, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                    }
+                }
+
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // --- CARD 1: NOTIFICATION TYPES (New Dropdown) ---
+                // Count how many are active to show in subtitle
+                val activeCount = NotificationType.entries.toTypedArray().count { typeConfig.contains(it.name) }
+                val activeSubtitle = stringResource(R.string.active_notifications_subtitle, activeCount)
+
+                ExpandableSettingCard(
+                    title = stringResource(R.string.active_notifications_title), // "Notification Types"
+                    icon = Icons.Default.Notifications,
+                    subtitle = activeSubtitle
+                ) {
+                    NotificationTypesContent(
+                        app = app,
+                        typeConfig = typeConfig,
+                        viewModel = viewModel,
+                        onNavConfigClick = { onDismiss(); onNavConfigClick() },
+                        navEditDesc = navEditDesc
                     )
                 }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // --- CARD 2: APPEARANCE ---
+                ExpandableSettingCard(
+                    title = stringResource(R.string.island_appearance),
+                    icon = Icons.Default.Palette
+                ) {
+                    AppearanceSettingsContent(
+                        appConfig = appIslandConfig,
+                        globalConfig = globalConfig,
+                        onUpdate = { viewModel.updateAppIslandConfig(app.packageName, it) },
+                        activeDesc = activeDesc,
+                        inactiveDesc = inactiveDesc
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // --- CARD 3: FILTERS ---
+                val blockedCount = blockedTerms.size
+                val blockedBadge = if (blockedCount > 0) stringResource(R.string.blocked_terms_active_count, blockedCount) else null
+
+                ExpandableSettingCard(
+                    title = stringResource(R.string.blocked_terms),
+                    icon = Icons.Default.Block,
+                    subtitle = blockedBadge
+                ) {
+                    BlocklistEditor(
+                        terms = blockedTerms,
+                        onUpdate = { newSet -> viewModel.updateAppBlockedTerms(app.packageName, newSet) }
+                    )
+                }
+
+                // Bottom Spacer for scrolling
+                Spacer(modifier = Modifier.height(24.dp))
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // =====================================================================
-            // SECTION 1: NOTIFICATION TYPES
-            // Toggles specific features (e.g., Disable music island for this app)
-            // =====================================================================
-            Text(
-                text = stringResource(R.string.select_active_notifs),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            NotificationType.entries.forEach { type ->
-                val isChecked = typeConfig.contains(type.name)
-                val typeLabel = stringResource(type.labelRes)
-
-                // ACCESSIBILITY: Pre-load strings here because we cannot call
-                // @Composable functions inside the modifier.semantics block below.
-                val switchDesc = if (isChecked)
-                    stringResource(R.string.cd_disable_type, typeLabel)
-                else
-                    stringResource(R.string.cd_enable_type, typeLabel)
-
-                val navEditDesc = stringResource(R.string.cd_nav_edit)
-
-                Row(
+            // --- FIXED FOOTER ---
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                tonalElevation = 4.dp,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Button(
+                    onClick = onDismiss,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { viewModel.updateAppConfig(app.packageName, type, !isChecked) }
-                        .padding(vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(horizontal = 24.dp, vertical = 16.dp)
+                        .height(50.dp)
                 ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = typeLabel,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                    }
-
-                    // Special Edit Button for Navigation Type
-                    if (type == NotificationType.NAVIGATION) {
-                        IconButton(
-                            onClick = {
-                                onDismiss() // Close sheet before navigating
-                                onNavConfigClick()
-                            },
-                            modifier = Modifier.semantics {
-                                contentDescription = navEditDesc
-                            }
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Edit,
-                                contentDescription = null, // Handled by modifier above
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                        }
-                    }
-
-                    Switch(
-                        checked = isChecked,
-                        onCheckedChange = { viewModel.updateAppConfig(app.packageName, type, it) },
-                        modifier = Modifier.semantics {
-                            contentDescription = switchDesc
-                        }
-                    )
+                    Text(stringResource(R.string.done))
                 }
             }
+        }
+    }
+}
 
-            Spacer(modifier = Modifier.height(24.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
-            Spacer(modifier = Modifier.height(24.dp))
+@Composable
+fun NotificationTypesContent(
+    app: AppInfo,
+    typeConfig: Set<String>,
+    viewModel: AppListViewModel,
+    onNavConfigClick: () -> Unit,
+    navEditDesc: String
+) {
+    Column {
+        NotificationType.entries.forEach { type ->
+            val isChecked = typeConfig.contains(type.name)
+            val typeLabel = stringResource(type.labelRes)
+            val switchDesc = if (isChecked) stringResource(R.string.cd_disable_type, typeLabel)
+            else stringResource(R.string.cd_enable_type, typeLabel)
 
-            // =====================================================================
-            // SECTION 2: ISLAND APPEARANCE
-            // Override global settings (Timeout, Float) for this specific app
-            // =====================================================================
-            Text(
-                text = stringResource(R.string.island_appearance),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Logic: Null means "Inherit from Global". Non-null means "Custom Override".
-            val isUsingGlobal = appIslandConfig.isFloat == null
-
-            // ACCESSIBILITY: Resolve strings outside semantics block
-            val stateActive = stringResource(R.string.status_active)
-            val stateInactive = stringResource(R.string.status_finished) // Reusing "Finished" implies "Not active" context
-
-            // "Use Global Defaults" Checkbox Row
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable {
-                        if (isUsingGlobal) {
-                            // Switch to Custom: Pre-fill with current global values so the UI doesn't jump
-                            viewModel.updateAppIslandConfig(app.packageName, globalConfig)
-                        } else {
-                            // Switch to Global: Reset to nulls
-                            viewModel.updateAppIslandConfig(app.packageName, IslandConfig(null, null, null))
-                        }
-                    }
-                    .padding(vertical = 8.dp)
-                    .semantics {
-                        // Tell TalkBack if we are using global defaults or custom
-                        stateDescription = if (isUsingGlobal) stateActive else stateInactive
-                    },
+                    .clickable { viewModel.updateAppConfig(app.packageName, type, !isChecked) }
+                    .padding(vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Checkbox(checked = isUsingGlobal, onCheckedChange = null) // decorative, click handled by Row
-                Spacer(Modifier.width(12.dp))
-                Text(stringResource(R.string.use_global_default), style = MaterialTheme.typography.bodyLarge)
-            }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(typeLabel, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.SemiBold)
+                }
 
-            // Show controls only when NOT using global defaults
-            if (!isUsingGlobal) {
-                Card(
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                    modifier = Modifier.padding(top = 8.dp).fillMaxWidth()
-                ) {
-                    Column(Modifier.padding(16.dp)) {
-                        // Reusable control logic (Sliders/Switches)
-                        IslandSettingsControl(
-                            config = appIslandConfig,
-                            onUpdate = { newConfig ->
-                                viewModel.updateAppIslandConfig(app.packageName, newConfig)
-                            }
+                if (type == NotificationType.NAVIGATION) {
+                    IconButton(
+                        onClick = onNavConfigClick,
+                        modifier = Modifier.semantics { contentDescription = navEditDesc }
+                    ) {
+                        Icon(Icons.Default.Edit, null, tint = MaterialTheme.colorScheme.primary)
+                    }
+                }
+
+                Switch(
+                    checked = isChecked,
+                    onCheckedChange = { viewModel.updateAppConfig(app.packageName, type, it) },
+                    modifier = Modifier.semantics { contentDescription = switchDesc }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ExpandableSettingCard(
+    title: String,
+    icon: ImageVector,
+    subtitle: String? = null,
+    content: @Composable () -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "rotation")
+    val actionDesc = if (expanded) "Collapse $title" else "Expand $title"
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = !expanded }
+            .semantics { contentDescription = actionDesc }
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(icon, null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    if (subtitle != null) {
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (subtitle.contains("active", true)) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
                         )
                     }
                 }
+                Icon(
+                    Icons.Default.ArrowDropDown,
+                    null,
+                    modifier = Modifier.rotate(rotation)
+                )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Button(
-                onClick = onDismiss,
-                modifier = Modifier.fillMaxWidth().height(50.dp)
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
             ) {
-                Text(stringResource(R.string.done))
+                Column(modifier = Modifier.padding(top = 16.dp)) {
+                    HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.3f))
+                    content()
+                }
             }
+        }
+    }
+}
+
+@Composable
+fun AppearanceSettingsContent(
+    appConfig: IslandConfig,
+    globalConfig: IslandConfig,
+    onUpdate: (IslandConfig) -> Unit,
+    activeDesc: String,
+    inactiveDesc: String
+) {
+    val isUsingGlobal = appConfig.isFloat == null
+
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    if (isUsingGlobal) onUpdate(globalConfig)
+                    else onUpdate(IslandConfig(null, null, null))
+                }
+                .padding(vertical = 8.dp)
+                .semantics { stateDescription = if (isUsingGlobal) activeDesc else inactiveDesc },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(checked = isUsingGlobal, onCheckedChange = null)
+            Spacer(Modifier.width(12.dp))
+            Text(stringResource(R.string.use_global_default), style = MaterialTheme.typography.bodyLarge)
+        }
+
+        if (!isUsingGlobal) {
+            Spacer(Modifier.height(8.dp))
+            IslandSettingsControl(
+                config = appConfig,
+                onUpdate = onUpdate
+            )
+        } else {
+            Text(
+                text = stringResource(R.string.appearance_use_defaults_desc),
+                color = Color.Gray,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 8.dp, start = 8.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalBlockListScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalBlockListScreen.kt
@@ -1,0 +1,266 @@
+package com.d4viddf.hyperbridge.ui.screens.settings
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.data.AppPreferences
+import com.d4viddf.hyperbridge.ui.AppInfo
+import com.d4viddf.hyperbridge.ui.AppListViewModel
+import com.d4viddf.hyperbridge.ui.components.BlocklistEditor
+import kotlinx.coroutines.launch
+
+/**
+ * Main Screen: Global Rules + Entry point to App List
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GlobalBlocklistScreen(
+    onBack: () -> Unit,
+    onNavigateToAppList: () -> Unit
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val preferences = remember { AppPreferences(context) }
+
+    val globalBlockedTerms by preferences.globalBlockedTermsFlow.collectAsState(initial = emptySet())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.blocked_terms)) },
+                navigationIcon = {
+                    FilledTonalIconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            // 1. GLOBAL RULES TITLE
+            Text(
+                text = stringResource(R.string.global_rules),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 8.dp).semantics { heading() }
+            )
+
+            // GLOBAL EDITOR CARD
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+                shape = RoundedCornerShape(20.dp)
+            ) {
+                BlocklistEditor(
+                    terms = globalBlockedTerms,
+                    onUpdate = { scope.launch { preferences.setGlobalBlockedTerms(it) } },
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // 2. APP RULES TITLE
+            Text(
+                text = stringResource(R.string.app_specific_rules),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 8.dp).semantics { heading() }
+            )
+
+            // NAVIGATION ENTRY CARD (Fixed design)
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+                shape = RoundedCornerShape(20.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                SettingsItem(
+                    icon = Icons.Default.Apps,
+                    title = stringResource(R.string.app_specific_rules),
+                    subtitle = stringResource(R.string.manage_app_rules_desc),
+                    onClick = onNavigateToAppList
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Secondary Screen: List of Apps to configure
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BlocklistAppListScreen(
+    onBack: () -> Unit,
+    viewModel: AppListViewModel = viewModel()
+) {
+    val activeApps by viewModel.activeAppsState.collectAsState()
+    var selectedApp by remember { mutableStateOf<AppInfo?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.app_specific_rules)) },
+                navigationIcon = {
+                    FilledTonalIconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding).fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp) // Add spacing between cards
+        ) {
+            items(activeApps, key = { it.packageName }) { app ->
+                AppBlockItem(app = app, viewModel = viewModel) { selectedApp = app }
+            }
+        }
+    }
+
+    // Edit Dialog
+    if (selectedApp != null) {
+        AppBlocklistDialog(
+            app = selectedApp!!,
+            viewModel = viewModel,
+            onDismiss = { selectedApp = null }
+        )
+    }
+}
+
+@Composable
+fun AppBlockItem(
+    app: AppInfo,
+    viewModel: AppListViewModel,
+    onClick: () -> Unit
+) {
+    // Collect specific rules for this app to show count
+    val terms by viewModel.getAppBlockedTerms(app.packageName).collectAsState(initial = emptySet())
+    val count = terms.size
+
+    val subtitle = if (count > 0) {
+        stringResource(R.string.blocked_terms_count, count)
+    } else {
+        stringResource(R.string.no_active_rules)
+    }
+
+    val subtitleColor = if (count > 0) MaterialTheme.colorScheme.error else Color.Gray
+
+    // Wrapped in Card for consistent look with Priority List
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        onClick = onClick
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                bitmap = app.icon.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.size(40.dp).clip(RoundedCornerShape(8.dp))
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = app.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = subtitleColor
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            )
+        }
+    }
+}
+
+@Composable
+fun AppBlocklistDialog(
+    app: AppInfo,
+    viewModel: AppListViewModel,
+    onDismiss: () -> Unit
+) {
+    val blockedTerms by viewModel.getAppBlockedTerms(app.packageName).collectAsState(initial = emptySet())
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(app.name) },
+        text = {
+            BlocklistEditor(
+                terms = blockedTerms,
+                onUpdate = { viewModel.updateAppBlockedTerms(app.packageName, it) }
+            )
+        },
+        confirmButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(R.string.done))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/InfoScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/InfoScreen.kt
@@ -39,7 +39,8 @@ fun InfoScreen(
     onLicensesClick: () -> Unit,
     onBehaviorClick: () -> Unit,
     onGlobalSettingsClick: () -> Unit,
-    onHistoryClick: () -> Unit
+    onHistoryClick: () -> Unit,
+    onBlocklistClick: () -> Unit
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
@@ -149,6 +150,15 @@ fun InfoScreen(
                     title = stringResource(R.string.global_settings),
                     subtitle = stringResource(R.string.island_appearance),
                     onClick = onGlobalSettingsClick
+                )
+
+                HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant.copy(0.5f))
+
+                SettingsItem(
+                    icon = Icons.Default.Block,
+                    title = stringResource(R.string.blocked_terms),
+                    subtitle = "Manage spoiler protection and filters", // Add string resource
+                    onClick = onBlocklistClick
                 )
             }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -236,4 +236,23 @@
     <string name="nav_preview_instruction">Girar a la derecha</string>
     <string name="nav_preview_distance">200m</string>
     <string name="nav_preview_time">10:30</string>
+
+    <string name="blocked_terms">Términos Bloqueados</string>
+    <string name="blocked_terms_desc">Se ignorarán las notificaciones que contengan estas palabras.</string>
+    <string name="add_blocked_word">Añadir palabra (ej. \'Spoiler\')</string>
+    <string name="add">Añadir</string>
+    <string name="remove">Eliminar</string>
+    <string name="tap_to_configure_rules">Toca una app para configurar reglas de bloqueo específicas.</string>
+    <string name="spoiler_subtitle">Gestionar protección contra spoilers y filtros</string>
+
+    <string name="active_notifications_title">Tipos de Notificación</string>
+    <string name="active_notifications_subtitle">%d activas</string>
+    <string name="appearance_use_defaults_desc">Usando valores predeterminados del sistema para velocidad y comportamiento flotante.</string>
+    <string name="blocked_terms_active_count">%d reglas activas</string>
+
+    <string name="global_rules">Reglas Globales</string>
+    <string name="app_specific_rules">Reglas por Aplicación</string>
+    <string name="manage_app_rules_desc">Personaliza filtros para aplicaciones específicas</string>
+    <string name="blocked_terms_count">%d términos bloqueados</string>
+    <string name="no_active_rules">Sin reglas activas</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,4 +241,23 @@
     <string name="nav_preview_instruction">Turn Right</string>
     <string name="nav_preview_distance">200m</string>
     <string name="nav_preview_time">10:30</string>
+
+    <string name="blocked_terms">Blocked Terms</string>
+    <string name="blocked_terms_desc">Notifications containing these words will be ignored.</string>
+    <string name="add_blocked_word">Add word (e.g. \'Spoiler\')</string>
+    <string name="add">Add</string>
+    <string name="remove">Remove</string>
+    <string name="tap_to_configure_rules">Tap an app to configure specific block rules.</string>
+    <string name="spoiler_subtitle">Manage spoiler protection and filters</string>
+
+    <string name="active_notifications_title">Notification Types</string>
+    <string name="active_notifications_subtitle">%d active</string>
+    <string name="appearance_use_defaults_desc">Using system defaults for animation speed and floating behavior.</string>
+    <string name="blocked_terms_active_count">%d rules active</string>
+
+    <string name="global_rules">Global Rules</string>
+    <string name="app_specific_rules">App Specific Rules</string>
+    <string name="manage_app_rules_desc">Customize filters for specific applications</string>
+    <string name="blocked_terms_count">%d terms blocked</string>
+    <string name="no_active_rules">No active rules</string>
 </resources>


### PR DESCRIPTION
…ig sheet

- Implemented Blocked Terms logic: Users can now define words to block globally or per-app to prevent spoilers or unwanted notifications.
- Redesigned `AppConfigBottomSheet`: Replaced the tabbed layout with a vertical list using expandable cards. This fixes the "bouncy" animation issues when switching sections.
- Added `GlobalBlocklistScreen` as a central hub for managing filters.
- Added `BlocklistAppListScreen` to configure rules for specific apps, displaying active rule counts per app.
- Updated `NotificationReaderService` to filter notifications based on effective blocked terms (Global + App Specific).
- Standardized UI: App list items in the blocklist settings now use consistent Card styling.

Closes #6