### PR TITLE
feat(ui): redesign Design hub and refactor navigation structure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 35
         targetSdk = 36
         versionCode = 10
-        versionName = "0.4.0-dev08"
+        versionName = "0.4.0-dev09"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/ActiveAppsPage.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/ActiveAppsPage.kt
@@ -1,21 +1,33 @@
 package com.d4viddf.hyperbridge.ui.screens.home
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -23,7 +35,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.ui.AppInfo
@@ -38,83 +52,106 @@ fun ActiveAppsPage(
     apps: List<AppInfo>,
     isLoading: Boolean,
     viewModel: AppListViewModel,
-    onConfig: (AppInfo) -> Unit
+    onConfig: (AppInfo) -> Unit,
+    onSettingsClick: () -> Unit
 ) {
     val searchQuery = viewModel.activeSearch.collectAsState().value
     val selectedCategory = viewModel.activeCategory.collectAsState().value
     val sortOption = viewModel.activeSort.collectAsState().value
 
-    // [LOGIC] Hide pull indicator on first load
     val isRefreshing = isLoading && apps.isNotEmpty()
     val pullState = rememberPullToRefreshState()
 
-    Column(modifier = Modifier.fillMaxSize()) {
-
-        AppListFilterSection(
-            searchQuery = searchQuery,
-            onSearchChange = { viewModel.activeSearch.value = it },
-            selectedCategory = selectedCategory,
-            onCategoryChange = { viewModel.activeCategory.value = it },
-            sortOption = sortOption,
-            onSortChange = { viewModel.activeSort.value = it }
-        )
-
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        ) {
-            PullToRefreshBox(
-                isRefreshing = isRefreshing,
-                onRefresh = { viewModel.refreshApps() },
-                state = pullState,
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.TopCenter, // Updated
-                indicator = {
-                    PullToRefreshDefaults.LoadingIndicator(
-                        state = pullState,
-                        isRefreshing = isRefreshing,
-                        modifier = Modifier.align(Alignment.TopCenter),
-                    )
-                }
-            ) {
-                if (apps.isEmpty() && isLoading) {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        LoadingIndicator()
+    Scaffold(
+        // [FIX] Only respect Status Bars here. The bottom nav bar space is handled by the parent HomeScreen.
+        contentWindowInsets = WindowInsets.statusBars,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.app_name),style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold) },
+                actions = {Surface(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape) // Ensure ripple is circular
+                        .clickable(onClick = onSettingsClick), // [NEW] Added Clickable here
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(Icons.Rounded.Settings, stringResource(R.string.settings), modifier = Modifier.size(20.dp))
                     }
-                } else if (apps.isEmpty()) {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        EmptyState(
-                            title = stringResource(R.string.no_active_bridges),
-                            description = stringResource(R.string.no_active_bridges_desc),
-                            icon = Icons.Outlined.NotificationsOff
+                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+
+            AppListFilterSection(
+                searchQuery = searchQuery,
+                onSearchChange = { viewModel.activeSearch.value = it },
+                selectedCategory = selectedCategory,
+                onCategoryChange = { viewModel.activeCategory.value = it },
+                sortOption = sortOption,
+                onSortChange = { viewModel.activeSort.value = it }
+            )
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = { viewModel.refreshApps() },
+                    state = pullState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.TopCenter,
+                    indicator = {
+                        PullToRefreshDefaults.LoadingIndicator(
+                            state = pullState,
+                            isRefreshing = isRefreshing,
+                            modifier = Modifier.align(Alignment.TopCenter),
                         )
                     }
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 80.dp)
-                    ) {
-                        items(apps, key = { it.packageName }) { app ->
-                            Column(modifier = Modifier.animateItem()) {
-                                AppListItem(
-                                    app = app,
-                                    onToggle = { viewModel.toggleApp(app.packageName, false) },
-                                    onSettingsClick = { onConfig(app) },
-                                )
-                                HorizontalDivider(
-                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)
-                                )
-                            }
+                ) {
+                    if (apps.isEmpty() && isLoading) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            LoadingIndicator()
                         }
+                    } else if (apps.isEmpty()) {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            EmptyState(
+                                title = stringResource(R.string.no_active_bridges),
+                                description = stringResource(R.string.no_active_bridges_desc),
+                                icon = Icons.Outlined.NotificationsOff
+                            )
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(bottom = 80.dp)
+                        ) {
+                            items(apps, key = { it.packageName }) { app ->
+                                Column(modifier = Modifier.animateItem()) {
+                                    AppListItem(
+                                        app = app,
+                                        onToggle = { viewModel.toggleApp(app.packageName, false) },
+                                        onSettingsClick = { onConfig(app) },
+                                    )
+                                    HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)
+                                    )
+                                }
+                            }
 
-                        if (isLoading) {
-                            item {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    LoadingIndicator(modifier = Modifier.width(40.dp))
+                            if (isLoading) {
+                                item {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        LoadingIndicator(modifier = Modifier.width(40.dp))
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/LibraryPage.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/home/LibraryPage.kt
@@ -1,18 +1,43 @@
 package com.d4viddf.hyperbridge.ui.screens.home
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SearchOff
-import androidx.compose.material3.*
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.ui.AppInfo
@@ -27,92 +52,110 @@ fun LibraryPage(
     apps: List<AppInfo>,
     isLoading: Boolean,
     viewModel: AppListViewModel,
-    onConfig: (AppInfo) -> Unit
+    onConfig: (AppInfo) -> Unit,
+    onSettingsClick: () -> Unit
 ) {
     val searchQuery = viewModel.librarySearch.collectAsState().value
     val selectedCategory = viewModel.libraryCategory.collectAsState().value
     val sortOption = viewModel.librarySort.collectAsState().value
 
-    // [LOGIC] Only show the Pull Indicator if we have content.
-    // On first load (apps empty), we hide it so we can show the big centered loader instead.
     val isRefreshing = isLoading && apps.isNotEmpty()
     val pullState = rememberPullToRefreshState()
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        AppListFilterSection(
-            searchQuery = searchQuery,
-            onSearchChange = { viewModel.librarySearch.value = it },
-            selectedCategory = selectedCategory,
-            onCategoryChange = { viewModel.libraryCategory.value = it },
-            sortOption = sortOption,
-            onSortChange = { viewModel.librarySort.value = it }
-        )
-
-        // Wrapper Box to ensure weight is applied correctly
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        ) {
-            PullToRefreshBox(
-                isRefreshing = isRefreshing,
-                onRefresh = { viewModel.refreshApps() },
-                state = pullState,
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.TopCenter, // Updated to TopCenter
-                indicator = {
-                    PullToRefreshDefaults.LoadingIndicator(
-                        state = pullState,
-                        isRefreshing = isRefreshing,
-                        modifier = Modifier.align(Alignment.TopCenter),
-                    )
-                }
-            ) {
-                // 1. Initial Load / Refreshing Empty State
-                if (apps.isEmpty() && isLoading) {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        LoadingIndicator()
+    Scaffold(
+        // [FIX] Only respect Status Bars here.
+        contentWindowInsets = WindowInsets.statusBars,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.app_name),style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold) },
+                actions = {
+                    Surface(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape) // Ensure ripple is circular
+                        .clickable(onClick = onSettingsClick), // [NEW] Added Clickable here
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(Icons.Rounded.Settings, stringResource(R.string.settings), modifier = Modifier.size(20.dp))
                     }
                 }
-                // 2. Empty State (No results)
-                else if (apps.isEmpty()) {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        EmptyState(
-                            title = stringResource(R.string.no_apps_found),
-                            description = "",
-                            icon = Icons.Default.SearchOff
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            AppListFilterSection(
+                searchQuery = searchQuery,
+                onSearchChange = { viewModel.librarySearch.value = it },
+                selectedCategory = selectedCategory,
+                onCategoryChange = { viewModel.libraryCategory.value = it },
+                sortOption = sortOption,
+                onSortChange = { viewModel.librarySort.value = it }
+            )
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = { viewModel.refreshApps() },
+                    state = pullState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.TopCenter,
+                    indicator = {
+                        PullToRefreshDefaults.LoadingIndicator(
+                            state = pullState,
+                            isRefreshing = isRefreshing,
+                            modifier = Modifier.align(Alignment.TopCenter),
                         )
                     }
-                }
-                // 3. List Content
-                else {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 80.dp)
-                    ) {
-                        items(apps, key = { it.packageName }) { app ->
-                            Column(modifier = Modifier.animateItem()) {
-                                AppListItem(
-                                    app = app,
-                                    onToggle = { viewModel.toggleApp(app.packageName, it) },
-                                    onSettingsClick = { onConfig(app) },
-                                )
-                                HorizontalDivider(
-                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)
-                                )
-                            }
+                ) {
+                    if (apps.isEmpty() && isLoading) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            LoadingIndicator()
                         }
+                    }
+                    else if (apps.isEmpty()) {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            EmptyState(
+                                title = stringResource(R.string.no_apps_found),
+                                description = "",
+                                icon = Icons.Default.SearchOff
+                            )
+                        }
+                    }
+                    else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(bottom = 80.dp)
+                        ) {
+                            items(apps, key = { it.packageName }) { app ->
+                                Column(modifier = Modifier.animateItem()) {
+                                    AppListItem(
+                                        app = app,
+                                        onToggle = { viewModel.toggleApp(app.packageName, it) },
+                                        onSettingsClick = { onConfig(app) },
+                                    )
+                                    HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f)
+                                    )
+                                }
+                            }
 
-                        // Bottom Pagination Loader (only if we have content)
-                        if (isLoading) {
-                            item {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 24.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    LoadingIndicator(modifier = Modifier.width(40.dp))
+                            if (isLoading) {
+                                item {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 24.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        LoadingIndicator(modifier = Modifier.width(40.dp))
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalSettingsScreen.kt
@@ -1,14 +1,21 @@
 package com.d4viddf.hyperbridge.ui.screens.settings
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForwardIos
 import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.data.AppPreferences
@@ -65,5 +72,57 @@ fun GlobalSettingsScreen(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun SettingsItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        // Use AutoMirrored icon for RTL support
+        Icon(
+            imageVector = Icons.AutoMirrored.Rounded.ArrowForwardIos,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            modifier = Modifier.size(16.dp)
+        )
     }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/InfoScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/InfoScreen.kt
@@ -3,10 +3,8 @@ package com.d4viddf.hyperbridge.ui.screens.settings
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,7 +14,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -25,7 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.rounded.ArrowForwardIos
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Code
@@ -54,7 +51,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -63,6 +59,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -70,8 +67,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
@@ -93,22 +88,18 @@ fun InfoScreen(
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
-    // FIX: Setup Scroll Behavior state
-    val appBarState = rememberTopAppBarState()
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(appBarState)
-
-    // --- STATE ---
     var showLanguageDialog by remember { mutableStateOf(false) }
 
     val appVersion = remember {
         try { context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "1.0.0" }
-        catch (e: Exception) { "1.0.0" }
+        catch (_: Exception) { "1.0.0" }
     }
 
     val appIconBitmap = remember(context) {
         try { context.packageManager.getApplicationIcon(context.packageName).toBitmap().asImageBitmap() }
-        catch (e: Exception) { null }
+        catch (_: Exception) { null }
     }
 
     Scaffold(
@@ -116,12 +107,7 @@ fun InfoScreen(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             MediumFlexibleTopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.settings),
-                        fontWeight = FontWeight.Bold
-                    )
-                },
+                title = { Text(stringResource(R.string.settings), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     FilledTonalIconButton(
                         onClick = onBack,
@@ -133,7 +119,6 @@ fun InfoScreen(
                     }
                 },
                 scrollBehavior = scrollBehavior,
-                collapsedHeight = TopAppBarDefaults.MediumAppBarCollapsedHeight,
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,
                     scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer
@@ -141,109 +126,163 @@ fun InfoScreen(
             )
         }
     ) { padding ->
-        // FIX: LazyColumn is critical for LargeTopAppBar scroll physics
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = padding,
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // --- HEADER ---
-            item {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
-                ) {
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    if (appIconBitmap != null) {
-                        Image(
-                            bitmap = appIconBitmap,
-                            contentDescription = stringResource(R.string.logo_desc),
-                            modifier = Modifier.size(96.dp).padding(bottom = 12.dp)
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Default.Bolt,
-                            contentDescription = stringResource(R.string.logo_desc),
-                            modifier = Modifier
-                                .size(80.dp)
-                                .background(MaterialTheme.colorScheme.primaryContainer, CircleShape)
-                                .padding(16.dp),
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-
-                    Text(stringResource(R.string.app_name), style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
-                    Text(
-                        text = stringResource(R.string.developer_credit),
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(R.string.version_template, appVersion),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color.Gray
-                    )
-                    Spacer(modifier = Modifier.height(24.dp))
-                }
+            Spacer(modifier = Modifier.height(16.dp))
+            if (appIconBitmap != null) {
+                Image(
+                    bitmap = appIconBitmap,
+                    contentDescription = stringResource(R.string.logo_desc),
+                    modifier = Modifier.size(96.dp).padding(bottom = 12.dp)
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Default.Bolt,
+                    contentDescription = stringResource(R.string.logo_desc),
+                    modifier = Modifier
+                        .size(80.dp)
+                        .background(MaterialTheme.colorScheme.primaryContainer, CircleShape)
+                        .padding(16.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
             }
 
-            // --- CONFIGURATION ---
-            item {
-                Column(Modifier.padding(horizontal = 16.dp)) {
-                    SettingsGroupTitle(stringResource(R.string.group_configuration))
-                    SettingsGroupCard {
-                        SettingsItem(Icons.Default.SettingsSuggest, stringResource(R.string.system_setup), stringResource(R.string.system_setup_subtitle), onSetupClick)
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Tune, stringResource(R.string.island_behavior), stringResource(R.string.limit_strategy), onBehaviorClick)
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Palette, stringResource(R.string.global_settings), stringResource(R.string.island_appearance), onGlobalSettingsClick)
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Block, stringResource(R.string.blocked_terms), stringResource(R.string.spoiler_subtitle), onBlocklistClick)
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Save, stringResource(R.string.backup_restore_title), stringResource(R.string.backup_section_title), onBackupClick)
-                    }
-                    Spacer(modifier = Modifier.height(24.dp))
-                }
-            }
+            Text(stringResource(R.string.app_name), style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+            Text(
+                text = stringResource(R.string.developer_credit),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.version_template, appVersion),
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Gray
+            )
+            Spacer(modifier = Modifier.height(32.dp))
 
-            // --- ABOUT ---
-            item {
-                Column(Modifier.padding(horizontal = 16.dp)) {
-                    SettingsGroupTitle(stringResource(R.string.group_about))
-                    SettingsGroupCard {
-                        SettingsItem(Icons.Default.Language, stringResource(R.string.language), stringResource(R.string.language_desc)) { showLanguageDialog = true }
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Person, stringResource(R.string.developer), stringResource(R.string.developer_subtitle)) { uriHandler.openUri("https://d4viddf.com") }
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.History, stringResource(R.string.version_history), "0.1.0 - $appVersion", onHistoryClick)
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Code, stringResource(R.string.source_code), stringResource(R.string.source_code_subtitle)) { uriHandler.openUri("https://github.com/D4vidDf/HyperBridge") }
-                        HorizontalDivider(modifier = Modifier.padding(horizontal = 20.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(0.2f))
-                        SettingsItem(Icons.Default.Description, stringResource(R.string.licenses), stringResource(R.string.licenses_subtitle), onLicensesClick)
-                    }
-                    Spacer(modifier = Modifier.height(48.dp))
+            // --- CONFIGURATION GROUP ---
+            SettingsSection(
+                title = stringResource(R.string.group_configuration),
+                items = listOf(
+                    SettingsItemData(Icons.Default.SettingsSuggest, stringResource(R.string.system_setup), stringResource(R.string.system_setup_subtitle), onSetupClick),
+                    SettingsItemData(Icons.Default.Tune, stringResource(R.string.island_behavior), stringResource(R.string.limit_strategy), onBehaviorClick),
+                    SettingsItemData(Icons.Default.Palette, stringResource(R.string.global_settings), stringResource(R.string.island_appearance), onGlobalSettingsClick),
+                    SettingsItemData(Icons.Default.Block, stringResource(R.string.blocked_terms), stringResource(R.string.spoiler_subtitle), onBlocklistClick),
+                    SettingsItemData(Icons.Default.Save, stringResource(R.string.backup_restore_title), stringResource(R.string.backup_section_title), onBackupClick)
+                )
+            )
 
-                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        Text(
-                            text = stringResource(R.string.footer_made_with_love).parseBold(),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.outline
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(32.dp))
-                }
-            }
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // --- ABOUT GROUP ---
+            SettingsSection(
+                title = stringResource(R.string.group_about),
+                items = listOf(
+                    SettingsItemData(Icons.Default.Language, stringResource(R.string.language), stringResource(R.string.language_desc)) { showLanguageDialog = true },
+                    SettingsItemData(Icons.Default.Person, stringResource(R.string.developer), stringResource(R.string.developer_subtitle)) { uriHandler.openUri("https://d4viddf.com") },
+                    SettingsItemData(Icons.Default.History, stringResource(R.string.version_history), "0.1.0 - $appVersion", onHistoryClick),
+                    SettingsItemData(Icons.Default.Code, stringResource(R.string.source_code), stringResource(R.string.source_code_subtitle)) { uriHandler.openUri("https://github.com/D4vidDf/HyperBridge") },
+                    SettingsItemData(Icons.Default.Description, stringResource(R.string.licenses), stringResource(R.string.licenses_subtitle), onLicensesClick)
+                )
+            )
+
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Text(
+                text = stringResource(R.string.footer_made_with_love).parseBold(),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.outline
+            )
+            Spacer(modifier = Modifier.height(32.dp))
         }
     }
 
     if (showLanguageDialog) {
-        LanguageSelectorDialog(onDismiss = { showLanguageDialog = false })
+        LanguageSelectorDialog(onDismiss = { })
     }
 }
 
-// ... (Rest of helpers same as before) ...
+// --- COMPONENTS ---
+
+data class SettingsItemData(
+    val icon: ImageVector,
+    val title: String,
+    val subtitle: String,
+    val onClick: () -> Unit
+)
+
+@Composable
+fun SettingsSection(title: String, items: List<SettingsItemData>) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(start = 8.dp, bottom = 8.dp)
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            items.forEachIndexed { index, item ->
+                val shape = getSettingsShape(items.size, index)
+                SettingsOptionCard(item, shape)
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsOptionCard(item: SettingsItemData, shape: Shape) {
+    Card(
+        onClick = item.onClick,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+        shape = shape,
+        modifier = Modifier.fillMaxWidth().heightIn(min = 72.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(item.icon, null, tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.width(20.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(item.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Medium)
+                Text(item.subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Icon(
+                Icons.AutoMirrored.Rounded.ArrowForwardIos,
+                null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            )
+        }
+    }
+}
+
+// --- SHAPE LOGIC (Copied from ThemeCreator) ---
+
+fun getSettingsShape(groupSize: Int, index: Int): Shape {
+    if (groupSize <= 1) return RoundedCornerShape(24.dp)
+    val large = 24.dp
+    val small = 4.dp
+    return when (index) {
+        0 -> RoundedCornerShape(topStart = large, topEnd = large, bottomEnd = small, bottomStart = small)
+        groupSize - 1 -> RoundedCornerShape(topStart = small, topEnd = small, bottomEnd = large, bottomStart = large)
+        else -> RoundedCornerShape(small)
+    }
+}
+
+// --- DIALOGS ---
+
 @Composable
 fun LanguageSelectorDialog(onDismiss: () -> Unit) {
     val languages = mapOf(
@@ -256,7 +295,6 @@ fun LanguageSelectorDialog(onDismiss: () -> Unit) {
         "Korean" to "ko",
         "Русский" to "ru",
         "Українська" to "uk"
-
     )
     val currentAppLocales = AppCompatDelegate.getApplicationLocales()
     val initialTag = if (!currentAppLocales.isEmpty) currentAppLocales.toLanguageTags().split(",")[0] else ""
@@ -290,10 +328,7 @@ fun LanguageSelectorDialog(onDismiss: () -> Unit) {
                                 .padding(horizontal = 8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            RadioButton(
-                                selected = isSelected,
-                                onClick = null
-                            )
+                            RadioButton(selected = isSelected, onClick = null)
                             Spacer(modifier = Modifier.width(12.dp))
                             Text(
                                 text = name,
@@ -319,49 +354,4 @@ fun LanguageSelectorDialog(onDismiss: () -> Unit) {
             TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.cancel)) }
         }
     )
-}
-
-@Composable
-fun SettingsGroupTitle(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleMedium,
-        color = MaterialTheme.colorScheme.primary,
-        fontWeight = FontWeight.Bold,
-        modifier = Modifier.fillMaxWidth().padding(start = 12.dp, bottom = 8.dp, top = 8.dp).semantics { heading() }
-    )
-}
-
-@Composable
-fun SettingsGroupCard(content: @Composable ColumnScope.() -> Unit) {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
-        shape = RoundedCornerShape(24.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(vertical = 8.dp)) { content() }
-    }
-}
-
-@Composable
-fun SettingsItem(icon: ImageVector, title: String, subtitle: String, onClick: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth().clickable { onClick() }.padding(horizontal = 20.dp, vertical = 16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier.size(40.dp).background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f), CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(24.dp))
-        }
-        Spacer(modifier = Modifier.width(16.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(text = title, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(text = subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-        Icon(Icons.AutoMirrored.Filled.ArrowForward, null, tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f), modifier = Modifier.size(20.dp))
-    }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -568,4 +568,23 @@
     <string name="apps_action_save">Guardar configuración</string>
     <string name="apps_default_color">Color predeterminado</string>
     <string name="apps_action_count">%d acciones</string>
+
+    <string name="design_hero_customization_title">Personalización</string>
+    <string name="design_hero_customization_subtitle">Aprende a crear temas</string>
+    <string name="design_hero_pro_title">Funciones Pro</string>
+    <string name="design_hero_pro_subtitle">Desbloquea todo el potencial</string>
+    <string name="design_hero_community_title">Comunidad</string>
+    <string name="design_hero_community_subtitle">Únete a nuestro GitHub</string>
+
+    <string name="design_section_themes">Temas</string>
+    <string name="design_section_widgets">Widgets</string>
+
+    <string name="design_browse_more">Ver más</string>
+    <string name="design_add_new">Añadir nuevo</string>
+    <string name="design_add_design">Añadir diseño</string>
+    <string name="design_add_to_island">Añadir a la Isla</string>
+    <string name="design_system_widget_beta">Widget del sistema (Beta)</string>
+    <string name="design_get_themes">Obtener temas</string>
+    <string name="design_empty_widget_title">Añade tu primer widget</string>
+    <string name="design_active_count">%d Activos</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -556,4 +556,23 @@
     <string name="apps_action_save">Save Configuration</string>
     <string name="apps_default_color">Default Color</string>
     <string name="apps_action_count">%d actions</string>
+
+    <string name="design_hero_customization_title">Customization</string>
+    <string name="design_hero_customization_subtitle">Learn how to create themes</string>
+    <string name="design_hero_pro_title">Pro Features</string>
+    <string name="design_hero_pro_subtitle">Unlock more power</string>
+    <string name="design_hero_community_title">Community</string>
+    <string name="design_hero_community_subtitle">Join our GitHub</string>
+
+    <string name="design_section_themes">Themes</string>
+    <string name="design_section_widgets">Widgets</string>
+
+    <string name="design_browse_more">Browse More</string>
+    <string name="design_add_new">Add New</string>
+    <string name="design_add_design">Add Design</string>
+    <string name="design_add_to_island">Customization</string>
+    <string name="design_system_widget_beta">System Widget (Beta)</string>
+    <string name="design_get_themes">Get Themes</string>
+    <string name="design_empty_widget_title">Add your first Widget</string>
+    <string name="design_active_count">%d Active</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ agp = "8.13.1"
 datastorePreferences = "1.2.0"
 gson = "2.13.2"
 hyperislandKit = "0.4.4"
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 kotlinxSerializationJson = "1.9.0"
 ksp = "2.1.21-2.0.1"
 coreKtx = "1.17.0"
@@ -11,10 +11,10 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.0"
+activityCompose = "1.12.2"
 composeBom = "2025.11.01"
 materialIconsExtended = "1.7.8"
-ui = "1.9.5"
+ui = "1.10.0"
 roomCompiler = "2.8.4"
 roomRuntime = "2.8.4"
 roomKtx = "2.8.4"
@@ -39,7 +39,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.5.0-alpha09" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.5.0-alpha11" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "roomCompiler" }


### PR DESCRIPTION
- **Design Screen**: Completely revamped UI using Material 3 Carousels (`HeroCarousel`, `MultiBrowseCarousel`), added theme/widget preview cards, and split logic into stateful/stateless composables.
- **Navigation**: Moved `TopAppBar` ownership from `HomeScreen` to individual tabs (`ActiveAppsPage`, `LibraryPage`) to fix window inset handling and allow per-screen actions.
- **Settings UI**: Standardized `InfoScreen` and `GlobalSettingsScreen` using new `SettingsSection` and shaped card components; added Settings entry point to all main tabs.
- **Dependencies**: Updated Kotlin to 2.3.0, Material 3 to 1.5.0-alpha11, Compose UI to 1.10.0, and Activity to 1.12.2.
- Added localization resources for the new personalization UI and bumped version to `0.4.0-dev09`.