### PR TITLE
feat(widget): add favorites, recommended filtering, and update notice

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
@@ -315,4 +315,17 @@ class AppPreferences(context: Context) {
         dao.delete("widget_${id}_auto_update")
         dao.delete("widget_${id}_update_interval")
     }
+
+    // ========================================================================
+    //                        FAVORITE WIDGET APPS
+    // ========================================================================
+
+    val favoriteWidgetAppsFlow: Flow<Set<String>> = dao.getSettingFlow("favorite_widget_apps").map { it.deserializeSet() }
+
+    suspend fun toggleFavoriteWidgetApp(packageName: String, isFavorite: Boolean) {
+        val currentStr = dao.getSetting("favorite_widget_apps")
+        val currentSet = currentStr.deserializeSet()
+        val newSet = if (isFavorite) currentSet + packageName else currentSet - packageName
+        save("favorite_widget_apps", newSet.serialize())
+    }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/WidgetOverlayService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/WidgetOverlayService.kt
@@ -34,6 +34,8 @@ class WidgetOverlayService : Service() {
         const val WIDGET_CHANNEL_ID = "hyper_bridge_widget_channel"
         const val ACTION_TEST_WIDGET = "ACTION_TEST_WIDGET"
         const val ACTION_START_MONITORING = "ACTION_START_MONITORING"
+        const val ACTION_KILL_ALL_WIDGETS = "ACTION_KILL_ALL_WIDGETS"
+        const val ACTION_KILL_WIDGET = "ACTION_KILL_WIDGET"
     }
 
     private val serviceScope = CoroutineScope(Dispatchers.IO + Job())
@@ -73,12 +75,31 @@ class WidgetOverlayService : Service() {
                     }
                 }
             }
+            ACTION_KILL_ALL_WIDGETS -> {
+                // Instantly kill all active widgets
+                serviceScope.launch(Dispatchers.IO) {
+                    val savedIds = preferences.savedWidgetIdsFlow.first()
+                    savedIds.forEach { id ->
+                        notificationManager.cancel(9000 + id)
+                        widgetUpdateDebouncer.remove(id)
+                    }
+                }
+            }
+            ACTION_KILL_WIDGET -> {
+                // NEW: Instantly kill a specific widget
+                val widgetId = intent.getIntExtra("WIDGET_ID", -1)
+                if (widgetId != -1) {
+                    notificationManager.cancel(9000 + widgetId)
+                    widgetUpdateDebouncer.remove(widgetId) // Clean up memory
+                }
+            }
             ACTION_START_MONITORING -> {
                 // Ensure service is sticky
             }
         }
         return START_STICKY
     }
+
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
     private fun startMonitoringWidgets() {
         serviceScope.launch {

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/design/SavedAppWidgetsScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/design/SavedAppWidgetsScreen.kt
@@ -1,5 +1,6 @@
 package com.d4viddf.hyperbridge.ui.screens.design
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Drawable
 import android.view.View
@@ -28,6 +29,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Widgets
 import androidx.compose.material3.*
@@ -48,15 +50,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.d4viddf.hyperbridge.R
 import com.d4viddf.hyperbridge.data.AppPreferences
 import com.d4viddf.hyperbridge.data.widget.WidgetManager
 import com.d4viddf.hyperbridge.models.WidgetSize
-import com.d4viddf.hyperbridge.ui.components.EmptyState // Import EmptyState
+import com.d4viddf.hyperbridge.ui.components.EmptyState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -81,21 +83,41 @@ fun SavedAppWidgetsScreen(
     val scope = rememberCoroutineScope()
     val preferences = remember { AppPreferences(context.applicationContext) }
 
+    val favorites by preferences.favoriteWidgetAppsFlow.collectAsState(initial = emptySet())
+    val savedIds by preferences.savedWidgetIdsFlow.collectAsState(initial = null) // Reactive listening for newly added widgets!
+
     var allGroups by remember { mutableStateOf<List<SavedWidgetGroup>>(emptyList()) }
     var searchQuery by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(true) }
+    var tabIndex by remember { mutableIntStateOf(1) } // 0 = Favorites, 1 = All
 
+    var showPermissionReminder by remember { mutableStateOf(false) }
     val refreshTrigger = remember { mutableStateOf(0) }
 
     val pullState = rememberPullToRefreshState()
     val isRefreshing = isLoading && allGroups.isNotEmpty()
 
-    LaunchedEffect(refreshTrigger.value) {
+    // App Update Permission Reminder Logic
+    LaunchedEffect(Unit) {
+        val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+        val currentVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toInt()
+        val sharedPrefs = context.getSharedPreferences("hyperbridge_internal", Context.MODE_PRIVATE)
+        val lastVersion = sharedPrefs.getInt("last_seen_version", currentVersion)
+
+        if (lastVersion in 1 until currentVersion) {
+            showPermissionReminder = true
+        }
+        sharedPrefs.edit().putInt("last_seen_version", currentVersion).apply()
+    }
+
+    // Fetch Saved Widgets (Reacts to new widgets being added dynamically)
+    LaunchedEffect(savedIds, refreshTrigger.value) {
+        if (savedIds == null) return@LaunchedEffect
+
         isLoading = true
         withContext(Dispatchers.IO) {
-            val savedIds = preferences.savedWidgetIdsFlow.first()
             val groupsMap = mutableMapOf<String, MutableList<Int>>()
-            savedIds.forEach { id ->
+            savedIds!!.forEach { id ->
                 val info = WidgetManager.getWidgetInfo(context, id)
                 val pkg = info?.provider?.packageName ?: return@forEach
                 groupsMap.getOrPut(pkg) { mutableListOf() }.add(id)
@@ -120,16 +142,38 @@ fun SavedAppWidgetsScreen(
         isLoading = false
     }
 
-    val displayedGroups = remember(allGroups, searchQuery) {
-        if (searchQuery.isEmpty()) {
-            allGroups
-        } else {
-            allGroups.filter {
+    // Reactive Filtering (Favorites + Search)
+    val displayedGroups = remember(allGroups, searchQuery, tabIndex, favorites) {
+        var filtered = allGroups
+
+        // Filter by Favorites
+        if (tabIndex == 0) {
+            filtered = filtered.filter { favorites.contains(it.packageName) }
+        }
+
+        // Filter by Search Query
+        if (searchQuery.isNotEmpty()) {
+            filtered = filtered.filter {
                 it.appName.contains(searchQuery, ignoreCase = true)
             }.map {
                 it.copy(isExpanded = true)
             }
         }
+
+        filtered
+    }
+
+    if (showPermissionReminder) {
+        AlertDialog(
+            onDismissRequest = { showPermissionReminder = false },
+            title = { Text(stringResource(R.string.permission_reminder_title)) },
+            text = { Text(stringResource(R.string.permission_reminder_desc)) },
+            confirmButton = {
+                Button(onClick = { showPermissionReminder = false }) {
+                    Text(stringResource(R.string.got_it))
+                }
+            }
+        )
     }
 
     Scaffold(
@@ -139,7 +183,7 @@ fun SavedAppWidgetsScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(stringResource(R.string.saved_widgets_title), fontWeight = FontWeight.Bold)
 
-                        // [NEW] Beta Badge
+                        // Beta Badge
                         Spacer(Modifier.width(8.dp))
                         Surface(
                             color = MaterialTheme.colorScheme.tertiaryContainer,
@@ -154,7 +198,7 @@ fun SavedAppWidgetsScreen(
                             )
                         }
                     }
-                        },
+                },
                 navigationIcon = {
                     FilledTonalIconButton(
                         onClick = onBack,
@@ -165,15 +209,79 @@ fun SavedAppWidgetsScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
                     }
                 },
+                actions = {
+                    if (allGroups.isNotEmpty()) {
+                        FilledTonalIconButton(
+                            onClick = {
+                                val intent = Intent(context, com.d4viddf.hyperbridge.service.WidgetOverlayService::class.java).apply {
+                                    action = "ACTION_KILL_ALL_WIDGETS"
+                                }
+                                context.startService(intent)
+                            },
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                        ) {
+                            Icon(Icons.Outlined.Block, contentDescription = stringResource(R.string.kill_all_widgets))
+                        }
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
             )
         },
+        floatingActionButtonPosition = FabPosition.Center,
         floatingActionButton = {
-            ExtendedFloatingActionButton(
-                onClick = onAddMore,
-                icon = { Icon(Icons.Default.Add, null) },
-                text = { Text(stringResource(R.string.new_widget_fab)) }
-            )
+            // A full-width Box so the Toolbar can be centered and the FAB right-aligned
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                // Centered Filter Toolbar
+                Box(modifier = Modifier.align(Alignment.Center)) {
+                    HorizontalFloatingToolbar(
+                        expanded = true,
+                        content = {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                modifier = Modifier.padding(horizontal = 4.dp)
+                            ) {
+                                TextButton(
+                                    onClick = { tabIndex = 0 },
+                                    colors = ButtonDefaults.textButtonColors(
+                                        containerColor = if (tabIndex == 0) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
+                                        contentColor = if (tabIndex == 0) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                ) {
+                                    Text(stringResource(R.string.favorites), fontWeight = FontWeight.SemiBold)
+                                }
+
+                                TextButton(
+                                    onClick = { tabIndex = 1 },
+                                    colors = ButtonDefaults.textButtonColors(
+                                        containerColor = if (tabIndex == 1) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
+                                        contentColor = if (tabIndex == 1) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                ) {
+                                    Text(stringResource(R.string.all), fontWeight = FontWeight.SemiBold)
+                                }
+                            }
+                        }
+                    )
+                }
+
+                // Add FAB aligned to the far right
+                FloatingActionButton(
+                    onClick = onAddMore,
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = "Add Widget")
+                }
+            }
         },
         containerColor = MaterialTheme.colorScheme.surface
     ) { padding ->
@@ -227,7 +335,6 @@ fun SavedAppWidgetsScreen(
                             LoadingIndicator()
                         }
                     } else if (displayedGroups.isEmpty()) {
-                        // [UPDATED] Use EmptyState Component
                         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                             EmptyState(
                                 title = stringResource(R.string.no_saved_widgets),
@@ -238,7 +345,7 @@ fun SavedAppWidgetsScreen(
                     } else {
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 80.dp),
+                            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 100.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             items(displayedGroups, key = { it.packageName }) { group ->
@@ -251,6 +358,14 @@ fun SavedAppWidgetsScreen(
                                         onToggle = { expanded = !expanded },
                                         onEdit = onEditWidget,
                                         onDelete = { widgetId ->
+                                            // 1. Instantly kill the active Island notification
+                                            val killIntent = Intent(context, com.d4viddf.hyperbridge.service.WidgetOverlayService::class.java).apply {
+                                                action = "ACTION_KILL_WIDGET"
+                                                putExtra("WIDGET_ID", widgetId)
+                                            }
+                                            context.startService(killIntent)
+
+                                            // 2. Remove from database and refresh UI
                                             scope.launch {
                                                 preferences.removeWidgetId(widgetId)
                                                 refreshTrigger.value++

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/design/WidgetPickerScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/design/WidgetPickerScreen.kt
@@ -16,7 +16,20 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,9 +41,38 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material.icons.outlined.Widgets
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -44,8 +86,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
 import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.data.AppPreferences
 import com.d4viddf.hyperbridge.data.widget.WidgetManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 data class WidgetAppGroup(
@@ -56,7 +100,7 @@ data class WidgetAppGroup(
     val isExpanded: Boolean = false
 )
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun WidgetPickerScreen(
     onBack: () -> Unit,
@@ -64,9 +108,14 @@ fun WidgetPickerScreen(
 ) {
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
+    val scope = rememberCoroutineScope()
+    val preferences = remember { AppPreferences(context.applicationContext) }
+
+    val favorites by preferences.favoriteWidgetAppsFlow.collectAsState(initial = emptySet())
 
     var allGroups by remember { mutableStateOf<List<WidgetAppGroup>>(emptyList()) }
     var searchQuery by remember { mutableStateOf("") }
+    var tabIndex by remember { mutableIntStateOf(0) } // 0 = Recommended, 1 = All
     var pendingWidgetId by remember { mutableStateOf(-1) }
 
     val bindLauncher = rememberLauncherForActivityResult(
@@ -84,37 +133,41 @@ fun WidgetPickerScreen(
         withContext(Dispatchers.IO) {
             val manager = AppWidgetManager.getInstance(context)
             val providers = manager.installedProviders
-
             val grouped = providers.groupBy { it.provider.packageName }
 
-            val uiGroups = grouped.map { (pkg, list) ->
-                val appName = try {
-                    val appInfo = context.packageManager.getApplicationInfo(pkg, 0)
-                    context.packageManager.getApplicationLabel(appInfo).toString()
-                } catch (e: Exception) { pkg }
-
-                val icon = try {
-                    context.packageManager.getApplicationIcon(pkg)
+            val uiGroups = grouped.mapNotNull { (pkg, list) ->
+                try {
+                    val appName = context.packageManager.getApplicationLabel(context.packageManager.getApplicationInfo(pkg, 0)).toString()
+                    val icon = context.packageManager.getApplicationIcon(pkg)
+                    WidgetAppGroup(pkg, appName, icon, list)
                 } catch (e: Exception) { null }
-
-                WidgetAppGroup(pkg, appName, icon, list)
             }.sortedBy { it.appName }
 
             allGroups = uiGroups
         }
     }
 
-    val displayedGroups = remember(allGroups, searchQuery) {
-        if (searchQuery.isEmpty()) {
-            allGroups
-        } else {
-            allGroups.filter {
-                it.appName.contains(searchQuery, ignoreCase = true)
-            }.map {
-                it.copy(isExpanded = true)
+    val displayedGroups = allGroups.mapNotNull { group ->
+        val filteredWidgets = if (tabIndex == 0) {
+            group.widgets.filter { w ->
+                // Filter specifically for 1x4 and 2x4 layouts (Compatible with Island sizes)
+                if (android.os.Build.VERSION.SDK_INT >= 31) {
+                    w.targetCellWidth == 4 && (w.targetCellHeight == 1 || w.targetCellHeight == 2)
+                } else {
+                    w.minWidth >= 200 && w.minHeight <= 150 // Rough estimation for older Android versions
+                }
             }
-        }
-    }
+        } else group.widgets
+
+        if (filteredWidgets.isNotEmpty()) group.copy(widgets = filteredWidgets) else null
+    }.filter {
+        if (searchQuery.isNotEmpty()) it.appName.contains(searchQuery, ignoreCase = true) else true
+    }.map {
+        if (searchQuery.isNotEmpty()) it.copy(isExpanded = true) else it
+    }.sortedWith(
+        compareByDescending<WidgetAppGroup> { favorites.contains(it.packageName) }
+            .thenBy { it.appName }
+    )
 
     Scaffold(
         topBar = {
@@ -122,8 +175,6 @@ fun WidgetPickerScreen(
                 title = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(stringResource(R.string.widget_picker_title), fontWeight = FontWeight.Bold)
-
-                        // [NEW] Beta Badge
                         Spacer(Modifier.width(8.dp))
                         Surface(
                             color = MaterialTheme.colorScheme.tertiaryContainer,
@@ -138,7 +189,7 @@ fun WidgetPickerScreen(
                             )
                         }
                     }
-                        },
+                },
                 navigationIcon = {
                     FilledTonalIconButton(
                         onClick = onBack,
@@ -149,9 +200,32 @@ fun WidgetPickerScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                )
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
+            )
+        },
+        floatingActionButtonPosition = FabPosition.Center,
+        floatingActionButton = {
+            HorizontalFloatingToolbar(
+                expanded = true,
+                content = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        ToolbarOption(
+                            selected = tabIndex == 0,
+                            icon = Icons.Outlined.Star,
+                            text = stringResource(R.string.recommended),
+                            onClick = { tabIndex = 0 }
+                        )
+                        ToolbarOption(
+                            selected = tabIndex == 1,
+                            icon = Icons.Outlined.Widgets,
+                            text = stringResource(R.string.all),
+                            onClick = { tabIndex = 1 }
+                        )
+                    }
+                }
             )
         },
         containerColor = MaterialTheme.colorScheme.surface
@@ -176,10 +250,8 @@ fun WidgetPickerScreen(
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     colors = TextFieldDefaults.colors(
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                        disabledIndicatorColor = Color.Transparent,
-                        errorIndicatorColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent, unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent, errorIndicatorColor = Color.Transparent,
                         focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                         unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                     )
@@ -188,17 +260,22 @@ fun WidgetPickerScreen(
 
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp),
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 80.dp), // Extra padding for the floating bar
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 items(displayedGroups, key = { it.packageName }) { group ->
                     var expanded by remember(group.packageName, searchQuery) { mutableStateOf(group.isExpanded) }
+                    val isFavorite = favorites.contains(group.packageName)
 
                     Box(modifier = Modifier.animateItem()) {
                         AppGroupItem(
                             group = group,
                             isExpanded = expanded,
+                            isFavorite = isFavorite,
                             onToggle = { expanded = !expanded },
+                            onFavoriteToggle = {
+                                scope.launch { preferences.toggleFavoriteWidgetApp(group.packageName, !isFavorite) }
+                            },
                             onSelectWidget = { provider ->
                                 val widgetId = WidgetManager.allocateId(context)
                                 val allowed = WidgetManager.bindWidget(context, widgetId, provider.provider)
@@ -226,7 +303,9 @@ fun WidgetPickerScreen(
 fun AppGroupItem(
     group: WidgetAppGroup,
     isExpanded: Boolean,
+    isFavorite: Boolean,
     onToggle: () -> Unit,
+    onFavoriteToggle: () -> Unit,
     onSelectWidget: (AppWidgetProviderInfo) -> Unit
 ) {
     val numWidget = pluralStringResource(R.plurals.widget_count_fmt, group.widgets.size, group.widgets.size)
@@ -267,6 +346,15 @@ fun AppGroupItem(
                         text = numWidget,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                // [NEW] Star Button
+                IconButton(onClick = onFavoriteToggle) {
+                    Icon(
+                        imageVector = if (isFavorite) Icons.Rounded.Star else Icons.Outlined.StarBorder,
+                        contentDescription = "Favorite",
+                        tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
 
@@ -318,7 +406,21 @@ fun WidgetChildItem(
 ) {
     val context = LocalContext.current
     val label = info.loadLabel(context.packageManager)
-    val dims = "${info.minWidth} × ${info.minHeight}"
+
+    // Convert dp dimensions to Android Grid Proportions (e.g., 4x1, 2x2)
+    val cols = if (android.os.Build.VERSION.SDK_INT >= 31) {
+        info.targetCellWidth
+    } else {
+        maxOf(1, Math.ceil((info.minWidth + 30) / 70.0).toInt())
+    }
+
+    val rows = if (android.os.Build.VERSION.SDK_INT >= 31) {
+        info.targetCellHeight
+    } else {
+        maxOf(1, Math.ceil((info.minHeight + 30) / 70.0).toInt())
+    }
+
+    val dims = "$cols × $rows"
 
     var preview by remember { mutableStateOf<Drawable?>(null) }
     LaunchedEffect(info) {
@@ -369,7 +471,8 @@ fun WidgetChildItem(
             text = label,
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
         )
         Text(
             text = dims,

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -555,4 +555,17 @@
     <string name="colors_label_hue">Tono</string>
     <string name="colors_label_saturation">Saturación</string>
     <string name="colors_label_lightness">Claridad</string>
+
+    <string name="colors_label_material_you">Material You (Sistema)</string>
+    <string name="colors_desc_material_you">Extrae los colores de tu fondo de pantalla actual.</string>
+
+    <string name="filter_compatible_widgets">Mostrar solo compatibles con la Isla</string>
+    <string name="kill_all_widgets">Detener widgets activos</string>
+    <string name="permission_reminder_title">Aviso de actualización</string>
+    <string name="permission_reminder_desc">¡HyperBridge se ha actualizado! Por favor, asegúrate de que los permisos de Inicio automático y Batería en segundo plano no hayan sido revocados silenciosamente por el sistema para que tus widgets sigan funcionando sin problemas.</string>
+    <string name="got_it">Entendido</string>
+
+    <string name="recommended">Recomendados</string>
+    <string name="all">Todos</string>
+    <string name="favorites">Favoritos</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -661,4 +661,14 @@
     <string name="colors_label_dynamic_modes">Dynamic Colors</string>
     <string name="colors_label_material_you">Material You (System)</string>
     <string name="colors_desc_material_you">Extracts colors from your current wallpaper.</string>
+
+    <string name="filter_compatible_widgets">Show Island Compatible Only</string>
+    <string name="kill_all_widgets">Kill Active Widgets</string>
+    <string name="permission_reminder_title">Update Notice</string>
+    <string name="permission_reminder_desc">HyperBridge has been updated! Please ensure that your Autostart and Background Battery permissions haven\'t been silently revoked by the system to keep your widgets running smoothly.</string>
+    <string name="got_it">Got it</string>
+
+    <string name="recommended">Recommended</string>
+    <string name="all">All</string>
+    <string name="favorites">Favorites</string>
 </resources>


### PR DESCRIPTION
- **Widget Picker**:
    - Implemented a "Recommended" filter to highlight 1x4 and 2x4 layouts compatible with the Island size.
    - Added a Favorite system for widget apps, allowing users to star apps for top-level sorting.
    - Added a floating navigation bar to switch between Recommended and All widgets.
    - Improved dimension display by converting DP to grid cell proportions (e.g., 4x2).
- **Saved Widgets**:
    - Added a persistent "Update Notice" dialog to remind users to check Autostart/Battery permissions after an app update.
    - Implemented a "Kill Active Widgets" action to instantly dismiss all running widget overlays.
    - Redesigned the UI with a centered filter toolbar (Favorites vs. All) and a dedicated Add FAB.
    - Added reactive listening for newly added widgets to ensure the list updates immediately.
- **Service & Data**:
    - Enhanced `WidgetOverlayService` with specific `ACTION_KILL_WIDGET` and `ACTION_KILL_ALL_WIDGETS` handlers for immediate UI cleanup.
    - Added `favoriteWidgetAppsFlow` to `AppPreferences` to persist starred widget providers.
- **Localization**:
    - Added English and Spanish strings for filters, permission reminders, and widget management.

CLOSE #72