### PR TITLE
build: update project dependencies and gradle configuration

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,6 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     id("org.jetbrains.kotlin.plugin.serialization") version "2.3.0"
@@ -18,7 +17,6 @@ android {
         targetSdk = 36
         versionCode = 16
         versionName = "0.5.0-alpha01"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -37,12 +35,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,11 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Strip Debug and Info logs in Release (AGP 9.1+ named level syntax)
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,9 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.builtInKotlin=true
+android.newDsl=true
+android.disallowKotlinSourceSets=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,20 @@
 [versions]
-agp = "8.13.2"
-datastorePreferences = "1.2.0"
+agp = "9.1.0"
+datastorePreferences = "1.2.1"
 gson = "2.13.2"
 hyperislandKit = "0.4.4"
-kotlin = "2.3.0"
-kotlinxSerializationJson = "1.9.0"
-ksp = "2.1.21-2.0.1"
-coreKtx = "1.17.0"
+kotlin = "2.3.20"
+kotlinxSerializationJson = "1.10.0"
+ksp = "2.3.2"
+coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.2"
-composeBom = "2025.11.01"
+activityCompose = "1.13.0"
+composeBom = "2026.03.00"
 materialIconsExtended = "1.7.8"
-ui = "1.10.0"
+ui = "1.10.5"
 roomCompiler = "2.8.4"
 roomRuntime = "2.8.4"
 roomKtx = "2.8.4"
@@ -40,7 +40,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.5.0-alpha11" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.5.0-alpha15" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "roomCompiler" }
@@ -53,6 +53,5 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3",
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sun Nov 23 16:10:02 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
- **Gradle & AGP**:
    - Upgraded Android Gradle Plugin (AGP) from `8.13.2` to `9.1.0`.
    - Upgraded Gradle wrapper from `8.13` to `9.3.1`.
    - Added `foojay-resolver-convention` plugin to `settings.gradle.kts` for automated toolchain management.
- **Dependencies**:
    - Updated Kotlin to `2.3.20` and KSP to `2.3.2`.
    - Updated Compose BOM to `2026.03.00` and Material3 to `1.5.0-alpha15`.
    - Updated various AndroidX libraries: `core-ktx` (`1.18.0`), `datastore-preferences` (`1.2.1`), `activity-compose` (`1.13.0`), and `ui` (`1.10.5`).
    - Bumped `kotlinx-serialization-json` to `1.10.0`.
- **Build Configuration**:
    - Removed `kotlin-android` plugin in favor of `kotlin-compose` and built-in Kotlin support.
    - Removed explicit `jvmTarget` configuration in `app/build.gradle.kts`.
    - Enabled several experimental/new Android Gradle properties in `gradle.properties`, including `android.builtInKotlin` and `android.newDsl`.
- **Optimization**:
    - Updated `proguard-rules.pro` to strip Debug and Info logs in release builds using AGP 9.1+ syntax.