### PR TITLE
fix(service): refine progress notification behavior and navigation state

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/MainActivity.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/MainActivity.kt
@@ -114,8 +114,8 @@ private fun MainNavigationContent(
 
     var showChangelog by remember { mutableStateOf(false) }
 
-    val initialStartRoute = remember { if (isSetupComplete) Screen.Home else Screen.Onboarding }
-    val allPossibleTopLevel = remember { setOf(Screen.Onboarding, Screen.Home) }
+    val initialStartRoute = remember(isSetupComplete) { if (isSetupComplete) Screen.Home else Screen.Onboarding }
+    val allPossibleTopLevel = remember(isSetupComplete) { setOf(Screen.Onboarding, Screen.Home) }
 
     val navigationState = rememberNavigationState(
         startRoute = initialStartRoute,

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -480,7 +480,7 @@ class NotificationReaderService : NotificationListenerService() {
                     navTranslator.translate(sbn, picKey, finalConfig, navLayout.first, navLayout.second, activeTheme)
                 }
                 NotificationType.TIMER -> timerTranslator.translate(sbn, picKey, finalConfig, activeTheme)
-                NotificationType.PROGRESS -> progressTranslator.translate(sbn, effectiveTitle, picKey, finalConfig, activeTheme)
+                NotificationType.PROGRESS -> progressTranslator.translate(sbn, effectiveTitle, picKey, finalConfig, activeTheme, isUpdate)
                 NotificationType.MEDIA -> mediaTranslator.translate(sbn, picKey, finalConfig)
                 else -> standardTranslator.translate(sbn, effectiveTitle, effectiveText, picKey, finalConfig, activeTheme)
             }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
@@ -26,7 +26,8 @@ class ProgressTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
         title: String,
         picKey: String,
         config: IslandConfig,
-        theme: HyperTheme?
+        theme: HyperTheme?,
+        isUpdate: Boolean
     ): HyperIslandData {
 
         // [FIX] Prioritize Progress Colors -> Global Highlight -> Default
@@ -39,10 +40,13 @@ class ProgressTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
         val customTick = getThemeBitmap(theme, "tick_icon")
 
         val builder = HyperIslandNotification.Builder(context, "bridge_${sbn.packageName}", title)
-        builder.setEnableFloat(config.isFloat ?: false)
 
         builder.setShowNotification(config.isShowShade ?: true)
-        builder.setIslandFirstFloat(config.isFloat ?: false)
+        
+        // Always enable float if the user wants it, but only "First Float" (expand) on the initial appearance
+        val isFloatEnabled = config.isFloat ?: false
+        builder.setEnableFloat(isFloatEnabled)
+        builder.setIslandFirstFloat(isFloatEnabled && !isUpdate)
 
         val extras = sbn.notification.extras
         val max = extras.getInt(Notification.EXTRA_PROGRESS_MAX, 0)
@@ -84,8 +88,8 @@ class ProgressTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
 
         if (isFinished) {
             builder.setBigIslandInfo(
-                left = ImageTextInfoLeft(1, PicInfo(1, hiddenKey), TextInfo("", "")),
-                right = ImageTextInfoRight(1, PicInfo(1, tickKey), TextInfo("Finished", title))
+                left = ImageTextInfoLeft(1, PicInfo(1, hiddenKey)),
+                right = ImageTextInfoRight(2, PicInfo(1, tickKey))
             )
             builder.setSmallIsland(tickKey)
             builder.setIslandConfig(timeout = config.timeout , dismissible = true, expandedTimeMs = config.floatTimeout)


### PR DESCRIPTION
- **Notification Service & Translators**:
    - **ProgressTranslator**: - Modified `translate` to accept an `isUpdate` flag. - Restricted "floating" behavior to the initial notification appearance only, preventing subsequent progress updates from re-triggering the float animation. - Refined `BigIslandInfo` layout for finished progress states by simplifying `ImageTextInfoLeft` and `ImageTextInfoRight` parameters (removing redundant text info). - Removed redundant `setIslandFirstFloat` call.
    - **NotificationReaderService**: Updated `PROGRESS` type handling to pass the `isUpdate` state to the translator.

- **UI & Navigation**:
    - **MainActivity**: Added `isSetupComplete` as a key to `remember` blocks for `initialStartRoute` and `allPossibleTopLevel` to ensure navigation state correctly reacts to setup completion changes.

Closes #156