### PR TITLE
feat(boot): add support for Direct Boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/receiver/BootReceiver.kt
@@ -12,6 +12,7 @@ class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         // Check for both standard boot and quick boot (some ROMs use quick)
         if (intent.action == Intent.ACTION_BOOT_COMPLETED ||
+            intent.action == Intent.ACTION_LOCKED_BOOT_COMPLETED ||
             intent.action == "android.intent.action.QUICKBOOT_POWERON") {
 
             Log.d("HyperBridge", "Boot completed detected.")


### PR DESCRIPTION
- **Boot Receiver**:
    - Updated `BootReceiver.kt` to handle `ACTION_LOCKED_BOOT_COMPLETED`, allowing the app to respond to boot events before the first user unlock.
    - Added `android.intent.action.LOCKED_BOOT_COMPLETED` to the `BootReceiver` intent filter in `AndroidManifest.xml`.

fixed #158 