### PR TITLE
refactor(service): refine floating behavior for progress notifications

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
@@ -45,8 +45,7 @@ class ProgressTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
         
         // Always enable float if the user wants it, but only "First Float" (expand) on the initial appearance
         val isFloatEnabled = config.isFloat ?: false
-        builder.setEnableFloat(isFloatEnabled)
-        builder.setIslandFirstFloat(isFloatEnabled && !isUpdate)
+        builder.setEnableFloat(isFloatEnabled && !isUpdate)
 
         val extras = sbn.notification.extras
         val max = extras.getInt(Notification.EXTRA_PROGRESS_MAX, 0)


### PR DESCRIPTION
- **Notification Logic**:
    - Updated `ProgressTranslator` to restrict the floating behavior (`setEnableFloat`) to only the initial appearance of a notification, preventing repeated floats during updates.
    - Removed the redundant `setIslandFirstFloat` call from the builder.

close #163 