### PR TITLE
fix(service): resolve WhatsApp duplication and update flashing/crashes

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -719,7 +719,7 @@ class NotificationReaderService : NotificationListenerService() {
         notification.extras.putString("miui.focus.param", data.jsonParam)
 
         if (!shouldAlertOnce) {
-            com.d4viddf.hyperbridge.util.ShizukuManager.notifyWithCancel(this, bridgeId, notification)
+            com.d4viddf.hyperbridge.util.ShizukuManager.notify(this, bridgeId, notification)
         } else {
             com.d4viddf.hyperbridge.util.ShizukuManager.notify(this, bridgeId, notification)
         }
@@ -851,6 +851,7 @@ class NotificationReaderService : NotificationListenerService() {
             // We previously blocked GROUP_ALERT_CHILDREN, but some apps like Telegram 
             // use it while silencing their actual children, leading to no alerts at all.
             // Let's just allow group summaries if they have actual text.
+            if (pkg.contains("whatsapp", ignoreCase = true)) return true
             if (text.isEmpty() || title.isEmpty()) return true
         }
 


### PR DESCRIPTION
* Modified `isJunkNotification` to explicitly block `FLAG_GROUP_SUMMARY` notifications for WhatsApp/WhatsApp Business. This prevents the engine from triggering two simultaneous islands for the same incoming message, while maintaining the previous fix for Telegram's grouped alerts.

* Reverted `postStandardNotification` to consistently use `.notify()` instead of `.notifyWithCancel()` when updating an existing active island. This stops the UI from rapidly tearing down and recreating the island on minor background updates, fixing the severe flashing behavior and subsequent system crashes under heavy notification loads.

Fixes #196
Fixes #197