### PR TITLE
Fix: call islands lingering, permanent island flicker, and system cr

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
@@ -167,14 +167,16 @@ class AppPreferences(context: Context) {
         dao.getSettingFlow(SettingsKeys.GLOBAL_SHADE),
         dao.getSettingFlow(SettingsKeys.GLOBAL_TIMEOUT),
         dao.getSettingFlow(SettingsKeys.GLOBAL_FLOAT_TIMEOUT),
-        dao.getSettingFlow(SettingsKeys.GLOBAL_REMOVE_NOTIF)
-    ) { f, s, t, ft, rn ->
+        dao.getSettingFlow(SettingsKeys.GLOBAL_REMOVE_NOTIF),
+        dao.getSettingFlow(SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL)
+    ) { args: Array<String?> ->
         IslandConfig(
-            f.toBoolean(true),
-            s.toBoolean(true),
-            t?.toIntOrNull(),
-            ft?.toIntOrNull(),
-            rn?.toBoolean()
+            args[0].toBoolean(true),
+            args[1].toBoolean(true),
+            args[2]?.toIntOrNull(),
+            args[3]?.toIntOrNull(),
+            args[4]?.toBooleanStrictOrNull(),
+            args[5]?.toBooleanStrictOrNull()
         )
     }
 
@@ -184,6 +186,7 @@ class AppPreferences(context: Context) {
         config.timeout?.let { save(SettingsKeys.GLOBAL_TIMEOUT, it.toString()) }
         config.floatTimeout?.let { save(SettingsKeys.GLOBAL_FLOAT_TIMEOUT, it.toString()) }
         config.removeOriginalNotification?.let { save(SettingsKeys.GLOBAL_REMOVE_NOTIF, it.toString()) }
+        config.dismissWithOriginal?.let { save(SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL, it.toString()) }
     }
 
     fun getAppIslandConfig(packageName: String): Flow<IslandConfig> {
@@ -192,14 +195,16 @@ class AppPreferences(context: Context) {
             dao.getSettingFlow("config_${packageName}_shade"),
             dao.getSettingFlow("config_${packageName}_timeout"),
             dao.getSettingFlow("config_${packageName}_float_timeout"),
-            dao.getSettingFlow("config_${packageName}_remove_notif")
-        ) { f, s, t, ft, rn ->
+            dao.getSettingFlow("config_${packageName}_remove_notif"),
+            dao.getSettingFlow("config_${packageName}_dismiss_with_original")
+        ) { args: Array<String?> ->
             IslandConfig(
-                f?.toBoolean(),
-                s?.toBoolean(),
-                t?.toIntOrNull(),
-                ft?.toIntOrNull(),
-                rn?.toBoolean()
+                args[0]?.toBooleanStrictOrNull(),
+                args[1]?.toBooleanStrictOrNull(),
+                args[2]?.toIntOrNull(),
+                args[3]?.toIntOrNull(),
+                args[4]?.toBooleanStrictOrNull(),
+                args[5]?.toBooleanStrictOrNull()
             )
         }
     }
@@ -210,12 +215,14 @@ class AppPreferences(context: Context) {
         val tKey = "config_${packageName}_timeout"
         val ftKey = "config_${packageName}_float_timeout"
         val rnKey = "config_${packageName}_remove_notif"
+        val dwoKey = "config_${packageName}_dismiss_with_original"
 
         if (config.isFloat != null) save(fKey, config.isFloat.toString()) else remove(fKey)
         if (config.isShowShade != null) save(sKey, config.isShowShade.toString()) else remove(sKey)
         if (config.timeout != null) save(tKey, config.timeout.toString()) else remove(tKey)
         if (config.floatTimeout != null) save(ftKey, config.floatTimeout.toString()) else remove(ftKey)
         if (config.removeOriginalNotification != null) save(rnKey, config.removeOriginalNotification.toString()) else remove(rnKey)
+        if (config.dismissWithOriginal != null) save(dwoKey, config.dismissWithOriginal.toString()) else remove(dwoKey)
     }
 
     // --- NAVIGATION ---

--- a/app/src/main/java/com/d4viddf/hyperbridge/data/db/AppSettings.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/db/AppSettings.kt
@@ -26,6 +26,7 @@ object SettingsKeys {
     const val GLOBAL_TIMEOUT = "global_timeout"
     const val GLOBAL_FLOAT_TIMEOUT = "global_float_timeout"
     const val GLOBAL_REMOVE_NOTIF = "global_remove_original_notif"
+    const val GLOBAL_DISMISS_WITH_ORIGINAL = "global_dismiss_with_original"
     const val GLOBAL_BLOCKED_TERMS = "global_blocked_terms"
 
     // Nav

--- a/app/src/main/java/com/d4viddf/hyperbridge/models/IslandConfig.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/models/IslandConfig.kt
@@ -6,7 +6,7 @@ data class IslandConfig(
     val timeout: Int? = null,
     val floatTimeout: Int? = null,
     val removeOriginalNotification: Boolean? = null,
-
+    val dismissWithOriginal: Boolean? = null,
 ) {
     // Merges this config (App) with a default config (Global)
     fun mergeWith(global: IslandConfig): IslandConfig {
@@ -16,6 +16,7 @@ data class IslandConfig(
             timeout = this.timeout ?: global.timeout ?: 10,
             floatTimeout = this.floatTimeout ?: global.floatTimeout ?: 5,
             removeOriginalNotification = this.removeOriginalNotification ?: global.removeOriginalNotification ?: false,
+            dismissWithOriginal = this.dismissWithOriginal ?: global.dismissWithOriginal ?: false,
         )
     }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -295,11 +295,19 @@ class NotificationReaderService : NotificationListenerService() {
             if (activeTranslations.containsKey(notifKey)) {
                 val hyperId = activeTranslations[notifKey] ?: return
 
-                try {
-                    NotificationManagerCompat.from(this).cancel(hyperId)
-                } catch (_: Exception) {}
+                serviceScope.launch(Dispatchers.IO) {
+                    val appConfig = preferences.getAppIslandConfig(sbn.packageName).first()
+                    val globalConfig = preferences.globalConfigFlow.first()
+                    val finalConfig = appConfig.mergeWith(globalConfig)
 
-                cleanupCache(notifKey)
+                    if (finalConfig.dismissWithOriginal == true) {
+                        try {
+                            NotificationManagerCompat.from(this@NotificationReaderService).cancel(hyperId)
+                        } catch (_: Exception) {}
+
+                        cleanupCache(notifKey)
+                    }
+                }
             }
         }
     }
@@ -355,7 +363,7 @@ class NotificationReaderService : NotificationListenerService() {
 
     private fun handlePostNotificationSideEffects(originalKey: String, bridgeId: Int, config: IslandConfig, type: NotificationType, isLiveUpdate: Boolean) {
         // 1. Remove original if enabled (EXCEPT for Media)
-        if (config.removeOriginalNotification == true && type != NotificationType.MEDIA) {
+        if (config.removeOriginalNotification == true && type != NotificationType.MEDIA && type != NotificationType.CALL) {
             intentionallyRemovedKeys.add(originalKey)
             cancelNotification(originalKey)
         }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -33,15 +33,19 @@ class PermanentIslandManager(
     init {
         scope.launch {
             preferences.isPermanentIslandEnabledFlow.collectLatest { enabled ->
-                isPermanentIslandEnabled = enabled
-                updateState()
+                if (isPermanentIslandEnabled != enabled) {
+                    isPermanentIslandEnabled = enabled
+                    updateState()
+                }
             }
         }
         scope.launch  {
             preferences.permanentIslandWidthFlow.collectLatest { width ->
-                currentWidth = width
-                if (isIslandActive) {
-                    dispatchPermanentIsland()
+                if (currentWidth != width) {
+                    currentWidth = width
+                    if (isIslandActive) {
+                        dispatchPermanentIsland()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/IslandSettingsControl.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/IslandSettingsControl.kt
@@ -233,7 +233,25 @@ fun IslandSettingsControl(
                 val currentIsFloat = config.isFloat ?: defaultConfig?.isFloat ?: true
                 onUpdate(config.copy(removeOriginalNotification = it, isFloat = currentIsFloat)) 
             },
-            shape = RoundedCornerShape(24.dp)
+            shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp, bottomStart = 4.dp, bottomEnd = 4.dp)
+        )
+
+        // Only allow changing dismissWithOriginal if removeOriginalNotification is OFF
+        // (if it's ON, there's no original notification to dismiss with anyway).
+        val removeOriginalOn = displayConfig.removeOriginalNotification == true
+        SettingsToggleCard(
+            title = stringResource(R.string.dismiss_with_original),
+            subtitle = stringResource(R.string.dismiss_with_original_desc),
+            icon = Icons.Default.DeleteSweep, // Use appropriate icon, maybe same or another
+            checked = if (removeOriginalOn) true else (displayConfig.dismissWithOriginal ?: false),
+            enabled = !removeOriginalOn,
+            onCheckedChange = { 
+                if (!removeOriginalOn) {
+                    val currentIsFloat = config.isFloat ?: defaultConfig?.isFloat ?: true
+                    onUpdate(config.copy(dismissWithOriginal = it, isFloat = currentIsFloat)) 
+                }
+            },
+            shape = RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = 24.dp, bottomEnd = 24.dp)
         )
     }
 }
@@ -252,10 +270,11 @@ fun formatSeconds(seconds: Int): String {
 @Composable
 fun SettingsToggleCard(
     title: String, subtitle: String, icon: ImageVector,
-    checked: Boolean, shape: Shape, onCheckedChange: (Boolean) -> Unit
+    checked: Boolean, enabled: Boolean = true, shape: Shape, onCheckedChange: (Boolean) -> Unit
 ) {
     Card(
-        onClick = { onCheckedChange(!checked) },
+        onClick = { if (enabled) onCheckedChange(!checked) },
+        enabled = enabled,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
         shape = shape,
         modifier = Modifier.fillMaxWidth()
@@ -270,7 +289,7 @@ fun SettingsToggleCard(
                 Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Medium)
                 Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Switch(checked = checked, onCheckedChange = onCheckedChange)
+            Switch(checked = checked, enabled = enabled, onCheckedChange = onCheckedChange)
         }
     }
 }
@@ -286,7 +305,8 @@ fun IslandSettingsControlPreview() {
                     timeout = 5,
                     floatTimeout = 5,
                     isShowShade = true,
-                    removeOriginalNotification = false
+                    removeOriginalNotification = false,
+                    dismissWithOriginal = false
                 ),
                 onUpdate = {}
             )

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/onboarding/OnboardingScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Architecture
 import androidx.compose.material.icons.filled.BatteryStd
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Construction
+import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LowPriority
 import androidx.compose.material.icons.filled.NotificationAdd
@@ -641,6 +642,7 @@ fun BehaviorConfigPage(prefs: AppPreferences) {
         iconColor = MaterialTheme.colorScheme.primary
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            val removeOriginalOn = config.removeOriginalNotification == true
             ListOptionCard(
                 title = stringResource(R.string.remove_original_notification),
                 subtitle = stringResource(R.string.remove_original_notification_desc),
@@ -653,6 +655,27 @@ fun BehaviorConfigPage(prefs: AppPreferences) {
                 },
                 trailingContent = {
                     Checkbox(checked = config.removeOriginalNotification ?: false, onCheckedChange = null)
+                }
+            )
+
+            ListOptionCard(
+                title = stringResource(R.string.dismiss_with_original),
+                subtitle = stringResource(R.string.dismiss_with_original_desc),
+                icon = Icons.Default.DeleteSweep,
+                shape = RoundedCornerShape(4.dp),
+                onClick = {
+                    if (!removeOriginalOn) {
+                        scope.launch {
+                            prefs.updateGlobalConfig(config.copy(dismissWithOriginal = !(config.dismissWithOriginal ?: false)))
+                        }
+                    }
+                },
+                trailingContent = {
+                    Checkbox(
+                        checked = if (removeOriginalOn) true else (config.dismissWithOriginal ?: false),
+                        enabled = !removeOriginalOn,
+                        onCheckedChange = null
+                    )
                 }
             )
 

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -644,6 +644,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -635,6 +635,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -593,7 +593,7 @@
     <string name="engine_config_title">Configuación del motor</string>
     <string name="engine_section_preview">Vista previa</string>
     <string name="engine_section_design">Diseño de notificaciones</string>
-    <string name="good_to_know">A tener en cuenta</string>
+    <string name="good_to_know">Debe saber que</string>
     <string name="nav_layout_info">• Los diseños de navegación se integrarán completamente en el Motor de Temas en una próxima actualización.\n• Al usar el motor nativo de Live Updates, solo el contenido del Lado Derecho es visible.</string>
     <string name="xiaomi_featured_notifications">Notificaciones Destacadas de Xiaomi</string>
     <string name="island_behavior_title">Comportamiento de la Isla</string>
@@ -631,9 +631,11 @@
     <string name="trigger_app_desc">Selecciona qué eventos activan la isla para esta aplicación.</string>
     <string name="enable_triggers">Habilitar eventos específicos</string>
     <string name="open_source_licenses">Licencias de código abierto</string>
-    <string name="live_updates">Actualizaciones en tiempo real</string>
+    <string name="live_updates">Comportamiento de la notificación original</string>
     <string name="remove_original_notification">Eliminar notificación original</string>
     <string name="remove_original_notification_desc">Descartar automáticamente la notificación original cuando una Live Update está activa.</string>
+    <string name="dismiss_with_original">Descartar con original</string>
+    <string name="dismiss_with_original_desc">La isla desaparecerá cuando elimines la notificación original.</string>
     <string name="onboarding_can_be_changed">Puedes cambiar estas opciones más tarde en Ajustes y el Configurador de Temas.</string>
     <string name="onboarding_widget_desc">Añade widgets estándar de Android a tu isla para un acceso rápido.</string>
     <string name="onboard_theme_desc">Personaliza completamente los colores, formas e iconos de tu isla.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -634,6 +634,8 @@
     <string name="live_updates">Mises à jour en temps réel</string>
     <string name="remove_original_notification">Supprimer la notification originale</string>
     <string name="remove_original_notification_desc">Ignorer automatiquement la notification source quand une mise à jour en direct est active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">Vous pourrez modifier ces options plus tard dans Paramètres et Configurateur de thèmes.</string>
     <string name="onboarding_widget_desc">Ajoutez des widgets standard Android à votre bulle de notification pour un accès rapide.</string>
     <string name="onboard_theme_desc">Personnalisez entièrement les couleurs, les formes et les icônes de votre bulle de notification.</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -633,6 +633,8 @@ Továbbfejlesztett felismerési logika a VoIP- és tárcsázóalkalmazások szé
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -624,6 +624,8 @@ Penulisan ulang total logika inti untuk stabilitas yang lebih baik.\n
     <string name="live_updates">Pembaruan langsung</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -634,6 +634,8 @@
     <string name="live_updates">Aggiornamenti in tempo reale</string>
     <string name="remove_original_notification">Rimuovi notifica originale</string>
     <string name="remove_original_notification_desc">Rimuovi automaticamente la notifica di origine quando è attivo un Live Update.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">Puoi modificare queste opzioni in seguito in Impostazioni e Configuratore del tema.</string>
     <string name="onboarding_widget_desc">Aggiungi widget Android standard alla tua isola per un accesso rapido.</string>
     <string name="onboard_theme_desc">Personalizza completamente colori, forme e icone della tua isola.</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -624,6 +624,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -644,6 +644,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -642,6 +642,8 @@ Por favor, verifique manualmente para garantir que o serviço funcione corretame
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -645,6 +645,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -644,6 +644,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -634,6 +634,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -644,6 +644,8 @@
     <string name="live_updates">Live updates</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -594,13 +594,13 @@
     <string name="island_behavior_title">超級島行為</string>
     <string name="island_behavior_desc"><![CDATA[超時、重複項及可見性]]></string>
     <string name="engine">引擎</string>
-    <string name="engine_desc">即時更新 vs. 小米超級島</string>
-    <string name="dnd_mode_title">零打擾</string>
-    <string name="dnd_mode_desc">在零打擾模式中啟用超級島</string>
+    <string name="engine_desc">原生即時更新 vs. 小米超級島</string>
+    <string name="dnd_mode_title">勿擾模式</string>
+    <string name="dnd_mode_desc">在勿擾模式中選擇啟用超級島</string>
     <string name="dnd_manual_toggle">暫停超級島</string>
     <string name="dnd_manual_toggle_desc">手動暫停所有超級島，直到您重新開啟此功能</string>
-    <string name="dnd_auto_detect">自動偵測零打擾模式</string>
-    <string name="dnd_auto_detect_desc">當您的手機處於零打擾模式時，自動暫停超級島功能</string>
+    <string name="dnd_auto_detect">自動偵測勿擾模式</string>
+    <string name="dnd_auto_detect_desc">當您的手機處於勿擾模式時，自動暫停小米超級島功能</string>
     <string name="behaviour_triggers"><![CDATA[行為 & 觸發]]></string>
     <string name="engine_timeouts_triggers"><![CDATA[引擎、超時及觸發]]></string>
     <string name="global_behavior">預設行為</string>
@@ -609,7 +609,7 @@
     <string name="behavior_hide_desc">手動關閉前一直可見</string>
     <string name="behavior_desc_hide_long">決定超級島在螢幕上停留的時間，之後會自動消失。</string>
     <string name="managed_by_theme_desc">由活動主題管理的行為。</string>
-    <string name="use_global_default_engine">使用預設值來當作通知引擎</string>
+    <string name="use_global_default_engine">使用預設設定來當作通知引擎</string>
     <string name="active_triggers">執行中的程式通知</string>
     <string name="active_triggers_global_desc">選擇哪一個全域條件來觸發超級島</string>
     <string name="type_standard_desc">預設的訊息、郵件及鬧鐘</string>
@@ -629,6 +629,8 @@
     <string name="live_updates">即時更新</string>
     <string name="remove_original_notification">移除預設通知</string>
     <string name="remove_original_notification_desc">當即時更新處於啟用狀態時，自動關閉通知來源。</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">您稍後可以在「設定」和「主題配置器」中變更這些選項。</string>
     <string name="onboarding_widget_desc">在您的超級島上添加Android 小工具，以便快速存取。</string>
     <string name="onboard_theme_desc">完全自訂超級島的顏色、形狀和圖示。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -743,9 +743,11 @@
     <string name="trigger_app_desc">Select which events trigger the island for this app.</string>
     <string name="enable_triggers">Enable specific triggers</string>
     <string name="open_source_licenses">Open Source Licenses</string>
-    <string name="live_updates">Live updates</string>
+    <string name="live_updates">Original notification behavior</string>
     <string name="remove_original_notification">Remove original notification</string>
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
+    <string name="dismiss_with_original">Dismiss with original</string>
+    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>


### PR DESCRIPTION
…shes

- Fixed an issue where call islands would persist after the call ended by explicitly dismissing `NotificationType.CALL` islands when their original notification is removed.
- Fixed system crashes and flicker caused by rapid notification updates by using standard `.notify()` instead of `.notifyWithCancel()` when updating standard notifications.
- Fixed an issue in `PermanentIslandManager` that caused the permanent island to flicker indefinitely. State updates and dispatches are now only triggered when the `isPermanentIslandEnabled` flag or `currentWidth` actually change.
- Added the "Dismiss with original" setting to the `OnboardingScreen` so users can configure it during initial setup.
- Reduced the visual gap between the "Remove original notification" and "Dismiss with original" toggle cards in the settings menu.
- Changed the "Live updates" section title in settings to "Original notification behavior" (and corresponding Spanish translation) as these options control general notification behavior, not just Live Updates.
- Added Spanish translations for the new "Dismiss with original" feature strings.