### PR TITLE
feat: implement Inline Reply overlay and theme customization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
     implementation(libs.hyperisland.kit)
+    implementation(libs.haze)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="moe.shizuku.manager.permission.API_V23" />
 
     <queries>
@@ -101,6 +102,15 @@
                 <data android:mimeType="application/x-zip-compressed" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".receiver.InlineReplyReceiver"
+            android:exported="false" />
+
+        <service
+            android:name=".service.InlineReplyService"
+            android:enabled="true"
+            android:exported="false" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
@@ -184,7 +184,8 @@ class AppPreferences(context: Context) {
         dao.getSettingFlow(SettingsKeys.GLOBAL_TIMEOUT),
         dao.getSettingFlow(SettingsKeys.GLOBAL_FLOAT_TIMEOUT),
         dao.getSettingFlow(SettingsKeys.GLOBAL_REMOVE_NOTIF),
-        dao.getSettingFlow(SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL)
+        dao.getSettingFlow(SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL),
+        dao.getSettingFlow(SettingsKeys.GLOBAL_ENABLE_INLINE_REPLY)
     ) { args: Array<String?> ->
         IslandConfig(
             args[0].toBoolean(true),
@@ -192,7 +193,8 @@ class AppPreferences(context: Context) {
             args[2]?.toIntOrNull(),
             args[3]?.toIntOrNull(),
             args[4]?.toBooleanStrictOrNull(),
-            args[5]?.toBooleanStrictOrNull()
+            args[5]?.toBooleanStrictOrNull(),
+            args[6]?.toBooleanStrictOrNull()
         )
     }
 
@@ -203,6 +205,7 @@ class AppPreferences(context: Context) {
         config.floatTimeout?.let { save(SettingsKeys.GLOBAL_FLOAT_TIMEOUT, it.toString()) }
         config.removeOriginalNotification?.let { save(SettingsKeys.GLOBAL_REMOVE_NOTIF, it.toString()) }
         config.dismissWithOriginal?.let { save(SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL, it.toString()) }
+        config.enableInlineReply?.let { save(SettingsKeys.GLOBAL_ENABLE_INLINE_REPLY, it.toString()) }
     }
 
     fun getAppIslandConfig(packageName: String): Flow<IslandConfig> {
@@ -212,7 +215,8 @@ class AppPreferences(context: Context) {
             dao.getSettingFlow("config_${packageName}_timeout"),
             dao.getSettingFlow("config_${packageName}_float_timeout"),
             dao.getSettingFlow("config_${packageName}_remove_notif"),
-            dao.getSettingFlow("config_${packageName}_dismiss_with_original")
+            dao.getSettingFlow("config_${packageName}_dismiss_with_original"),
+            dao.getSettingFlow("config_${packageName}_enable_inline_reply")
         ) { args: Array<String?> ->
             IslandConfig(
                 args[0]?.toBooleanStrictOrNull(),
@@ -220,7 +224,8 @@ class AppPreferences(context: Context) {
                 args[2]?.toIntOrNull(),
                 args[3]?.toIntOrNull(),
                 args[4]?.toBooleanStrictOrNull(),
-                args[5]?.toBooleanStrictOrNull()
+                args[5]?.toBooleanStrictOrNull(),
+                args[6]?.toBooleanStrictOrNull()
             )
         }
     }
@@ -232,6 +237,7 @@ class AppPreferences(context: Context) {
         val ftKey = "config_${packageName}_float_timeout"
         val rnKey = "config_${packageName}_remove_notif"
         val dwoKey = "config_${packageName}_dismiss_with_original"
+        val eirKey = "config_${packageName}_enable_inline_reply"
 
         if (config.isFloat != null) save(fKey, config.isFloat.toString()) else remove(fKey)
         if (config.isShowShade != null) save(sKey, config.isShowShade.toString()) else remove(sKey)
@@ -239,6 +245,7 @@ class AppPreferences(context: Context) {
         if (config.floatTimeout != null) save(ftKey, config.floatTimeout.toString()) else remove(ftKey)
         if (config.removeOriginalNotification != null) save(rnKey, config.removeOriginalNotification.toString()) else remove(rnKey)
         if (config.dismissWithOriginal != null) save(dwoKey, config.dismissWithOriginal.toString()) else remove(dwoKey)
+        if (config.enableInlineReply != null) save(eirKey, config.enableInlineReply.toString()) else remove(eirKey)
     }
 
     // --- NAVIGATION ---
@@ -497,7 +504,8 @@ class AppPreferences(context: Context) {
             memoryCache["config_${packageName}_timeout"]?.toIntOrNull(),
             memoryCache["config_${packageName}_float_timeout"]?.toIntOrNull(),
             memoryCache["config_${packageName}_remove_notif"]?.toBooleanStrictOrNull(),
-            memoryCache["config_${packageName}_dismiss_with_original"]?.toBooleanStrictOrNull()
+            memoryCache["config_${packageName}_dismiss_with_original"]?.toBooleanStrictOrNull(),
+            memoryCache["config_${packageName}_enable_inline_reply"]?.toBooleanStrictOrNull()
         )
     }
 
@@ -508,7 +516,8 @@ class AppPreferences(context: Context) {
             memoryCache[SettingsKeys.GLOBAL_TIMEOUT]?.toIntOrNull(),
             memoryCache[SettingsKeys.GLOBAL_FLOAT_TIMEOUT]?.toIntOrNull(),
             memoryCache[SettingsKeys.GLOBAL_REMOVE_NOTIF]?.toBooleanStrictOrNull(),
-            memoryCache[SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL]?.toBooleanStrictOrNull()
+            memoryCache[SettingsKeys.GLOBAL_DISMISS_WITH_ORIGINAL]?.toBooleanStrictOrNull(),
+            memoryCache[SettingsKeys.GLOBAL_ENABLE_INLINE_REPLY]?.toBooleanStrictOrNull()
         )
     }
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/data/db/AppSettings.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/db/AppSettings.kt
@@ -28,6 +28,7 @@ object SettingsKeys {
     const val GLOBAL_FLOAT_TIMEOUT = "global_float_timeout"
     const val GLOBAL_REMOVE_NOTIF = "global_remove_original_notif"
     const val GLOBAL_DISMISS_WITH_ORIGINAL = "global_dismiss_with_original"
+    const val GLOBAL_ENABLE_INLINE_REPLY = "global_enable_inline_reply"
     const val GLOBAL_BLOCKED_TERMS = "global_blocked_terms"
 
     // Nav

--- a/app/src/main/java/com/d4viddf/hyperbridge/models/IslandConfig.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/models/IslandConfig.kt
@@ -7,6 +7,7 @@ data class IslandConfig(
     val floatTimeout: Int? = null,
     val removeOriginalNotification: Boolean? = null,
     val dismissWithOriginal: Boolean? = null,
+    val enableInlineReply: Boolean? = null,
 ) {
     // Merges this config (App) with a default config (Global)
     fun mergeWith(global: IslandConfig): IslandConfig {
@@ -17,6 +18,7 @@ data class IslandConfig(
             floatTimeout = this.floatTimeout ?: global.floatTimeout ?: 5,
             removeOriginalNotification = this.removeOriginalNotification ?: global.removeOriginalNotification ?: false,
             dismissWithOriginal = this.dismissWithOriginal ?: global.dismissWithOriginal ?: false,
+            enableInlineReply = this.enableInlineReply ?: global.enableInlineReply ?: true,
         )
     }
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/models/theme/ThemeModels.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/models/theme/ThemeModels.kt
@@ -12,6 +12,7 @@ data class HyperTheme(
     @SerialName("default_actions") val defaultActions: Map<String, ActionConfig> = emptyMap(),
     @SerialName("default_progress") val defaultProgress: ProgressModule = ProgressModule(),
     @SerialName("default_navigation") val defaultNavigation: NavigationModule = NavigationModule(),
+    @SerialName("default_reply") val defaultReply: ReplyModule = ReplyModule(),
     val apps: Map<String, AppThemeOverride> = emptyMap(),
     val rules: List<ThemeRule> = emptyList()
 )
@@ -79,6 +80,7 @@ data class AppThemeOverride(
     val actions: Map<String, ActionConfig>? = null,
     val progress: ProgressModule? = null,
     val navigation: NavigationModule? = null,
+    @SerialName("reply_config") val replyConfig: ReplyModule? = null,
 
     // [NEW] App-specific behavior overrides
     @SerialName("use_native_live_updates") val useNativeLiveUpdates: Boolean? = null,
@@ -136,11 +138,25 @@ data class RuleConditions(
 @Serializable
 data class ThemeResource(val type: ResourceType, val value: String)
 
+@Serializable
+data class ReplyModule(
+    @SerialName("background_color") val backgroundColor: String? = null,
+    @SerialName("send_color") val sendColor: String? = null,
+    @SerialName("send_icon") val sendIcon: ThemeResource? = null,
+    @SerialName("textfield_background_color") val textfieldBackgroundColor: String? = null,
+    @SerialName("text_color") val textColor: String? = null,
+    @SerialName("color_mode") val colorMode: ColorMode? = null,
+    @SerialName("use_blur") val useBlur: Boolean = false,
+    @SerialName("textfield_corner_radius") val textfieldCornerRadius: Int = 24,
+    @SerialName("send_button_corner_radius") val sendButtonCornerRadius: Int = 24
+)
+
 enum class ResourceType { PRESET_DRAWABLE, LOCAL_FILE, URI_CONTENT }
 
 enum class ActionButtonMode { ICON, TEXT, BOTH }
 
 enum class ColorMode {
+    DEFAULT,        // Uses default system/app theme colors without overrides
     CUSTOM,         // Uses selectedColorHex
     APP_ICON,       // Extracts color from the notification's app icon
     MATERIAL_YOU    // Extracts color from the system wallpaper (Monet)

--- a/app/src/main/java/com/d4viddf/hyperbridge/receiver/InlineReplyReceiver.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/receiver/InlineReplyReceiver.kt
@@ -1,0 +1,33 @@
+package com.d4viddf.hyperbridge.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
+import com.d4viddf.hyperbridge.service.InlineReplyService
+
+class InlineReplyReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (!Settings.canDrawOverlays(context)) {
+            Toast.makeText(context, "Please grant 'Display over other apps' permission to use inline reply", Toast.LENGTH_LONG).show()
+            
+            // Optionally launch settings
+            val settingsIntent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            context.startActivity(settingsIntent)
+            return
+        }
+
+        val serviceIntent = Intent(context, InlineReplyService::class.java).apply {
+            putExtras(intent)
+        }
+        
+        try {
+            context.startService(serviceIntent)
+        } catch (_: Exception) {
+            Toast.makeText(context, "Failed to start reply service from background", Toast.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/InlineReplyService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/InlineReplyService.kt
@@ -1,0 +1,378 @@
+package com.d4viddf.hyperbridge.service
+
+import android.app.PendingIntent
+import android.app.RemoteInput
+import android.app.Service
+import android.content.Intent
+import android.graphics.Outline
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.Bundle
+import android.os.IBinder
+import android.util.Log
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.ViewOutlineProvider
+import android.view.WindowManager
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.d4viddf.hyperbridge.ui.theme.HyperBridgeTheme
+import androidx.core.graphics.toColorInt
+
+fun safeParseColorFallback(hex: String?, fallback: Color): Color {
+    if (hex == null) return fallback
+    return try {
+        Color(hex.toColorInt())
+    } catch (_: Exception) {
+        fallback
+    }
+}
+
+class InlineReplyService : Service(), LifecycleOwner, ViewModelStoreOwner, SavedStateRegistryOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    private val store = ViewModelStore()
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+
+    override val lifecycle: Lifecycle get() = lifecycleRegistry
+    override val viewModelStore: ViewModelStore get() = store
+    override val savedStateRegistry: SavedStateRegistry get() = savedStateRegistryController.savedStateRegistry
+
+    private var windowManager: WindowManager? = null
+    private var composeView: ComposeView? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        savedStateRegistryController.performRestore(null)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val pendingIntent = intent?.getParcelableExtra<PendingIntent>("pending_intent")
+        val resultKey = intent?.getStringExtra("result_key")
+        val packageName = intent?.getStringExtra("package_name") ?: ""
+
+        if (pendingIntent == null || resultKey == null) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        showOverlay(pendingIntent, resultKey, packageName)
+        return START_NOT_STICKY
+    }
+
+    private fun showOverlay(pendingIntent: PendingIntent, resultKey: String, packageName: String) {
+        if (composeView != null) return
+
+        composeView = ComposeView(this).apply {
+            setViewTreeLifecycleOwner(this@InlineReplyService)
+            setViewTreeViewModelStoreOwner(this@InlineReplyService)
+            setViewTreeSavedStateRegistryOwner(this@InlineReplyService)
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+            setContent {
+                val preferences = remember { com.d4viddf.hyperbridge.data.AppPreferences(this@InlineReplyService) }
+                val themeRepository = remember { com.d4viddf.hyperbridge.data.theme.ThemeRepository(this@InlineReplyService) }
+                val activeThemeId by preferences.activeThemeIdFlow.collectAsState(initial = null)
+                val activeTheme by themeRepository.activeTheme.collectAsState()
+
+                LaunchedEffect(activeThemeId) {
+                    activeThemeId?.let { themeRepository.activateTheme(it) }
+                }
+
+                val replyModule = activeTheme?.apps?.get(packageName)?.replyConfig ?: activeTheme?.defaultReply
+                
+                val useBlur = replyModule?.useBlur ?: true
+                val tfCornerRadius = replyModule?.textfieldCornerRadius ?: 24
+                val btnCornerRadius = replyModule?.sendButtonCornerRadius ?: 24
+
+                val tfBgColorHex = replyModule?.textfieldBackgroundColor
+                val sendColorHex = replyModule?.sendColor
+                val txtColorHex = replyModule?.textColor
+                val colorMode = replyModule?.colorMode ?: com.d4viddf.hyperbridge.models.theme.ColorMode.DEFAULT
+
+                HyperBridgeTheme {
+                    var message by remember { mutableStateOf("") }
+                    val focusRequester = remember { FocusRequester() }
+
+                    LaunchedEffect(Unit) {
+                        try {
+                            focusRequester.requestFocus()
+                        } catch (e: Exception) {
+                            Log.e("InlineReplyService", "Focus failed", e)
+                        }
+                    }
+
+                    val isMaterialYou = colorMode == com.d4viddf.hyperbridge.models.theme.ColorMode.MATERIAL_YOU
+                    val tfBgColor = if (isMaterialYou) MaterialTheme.colorScheme.surfaceVariant else (tfBgColorHex?.let { safeParseColorFallback(it, MaterialTheme.colorScheme.surfaceVariant) } ?: MaterialTheme.colorScheme.surfaceVariant)
+                    val sendParsedColor = if (isMaterialYou) MaterialTheme.colorScheme.primary else (sendColorHex?.let { safeParseColorFallback(it, MaterialTheme.colorScheme.primary) } ?: MaterialTheme.colorScheme.primary)
+                    val txtColor = if (isMaterialYou) MaterialTheme.colorScheme.onSurface else (txtColorHex?.let { safeParseColorFallback(it, MaterialTheme.colorScheme.onSurface) } ?: MaterialTheme.colorScheme.onSurface)
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Transparent)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                removeOverlayAndStop()
+                            },
+                        contentAlignment = Alignment.BottomCenter
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .navigationBarsPadding()
+                                .imePadding()
+                                .padding(16.dp),
+                            verticalAlignment = Alignment.Bottom
+                        ) {
+                            var tfRect by remember { mutableStateOf(android.graphics.Rect()) }
+                            var btnRect by remember { mutableStateOf(android.graphics.Rect()) }
+
+                            val currentView = LocalView.current
+                            val displayMetrics = currentView.resources.displayMetrics
+                            
+                            LaunchedEffect(tfRect, btnRect, tfCornerRadius, btnCornerRadius, useBlur) {
+                                if (useBlur && !tfRect.isEmpty && !btnRect.isEmpty) {
+                                    currentView.outlineProvider = object : ViewOutlineProvider() {
+                                        override fun getOutline(view: android.view.View, outline: Outline) {
+                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                                val path = android.graphics.Path()
+                                                path.addRoundRect(
+                                                    android.graphics.RectF(tfRect),
+                                                    tfCornerRadius.toFloat() * displayMetrics.density,
+                                                    tfCornerRadius.toFloat() * displayMetrics.density,
+                                                    android.graphics.Path.Direction.CW
+                                                )
+                                                path.addRoundRect(
+                                                    android.graphics.RectF(btnRect),
+                                                    btnCornerRadius.toFloat() * displayMetrics.density,
+                                                    btnCornerRadius.toFloat() * displayMetrics.density,
+                                                    android.graphics.Path.Direction.CW
+                                                )
+                                                outline.setPath(path)
+                                            }
+                                        }
+                                    }
+                                    val wParams = currentView.layoutParams as? WindowManager.LayoutParams
+                                    if (wParams != null) {
+                                        wParams.flags = wParams.flags or WindowManager.LayoutParams.FLAG_BLUR_BEHIND
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                            wParams.blurBehindRadius = 50
+                                        }
+                                        try { windowManager?.updateViewLayout(currentView, wParams) } catch (_: Exception) {}
+                                    }
+                                } else {
+                                    currentView.outlineProvider = null
+                                    val wParams = currentView.layoutParams as? WindowManager.LayoutParams
+                                    if (wParams != null) {
+                                        wParams.flags = wParams.flags and WindowManager.LayoutParams.FLAG_BLUR_BEHIND.inv()
+                                        try { windowManager?.updateViewLayout(currentView, wParams) } catch (_: Exception) {}
+                                    }
+                                }
+                            }
+
+                            
+                            Box(modifier = Modifier
+                                .weight(1f)
+                                .heightIn(
+                                    min = 56.dp,
+                                    max = 200.dp
+                                )
+                                .onGloballyPositioned { coords ->
+                                    val b = coords.boundsInWindow()
+                                    tfRect = android.graphics.Rect(b.left.toInt(), b.top.toInt(), b.right.toInt(), b.bottom.toInt())
+                                }
+                            ) {
+                                // Background Layer
+                                Box(modifier = Modifier
+                                    .matchParentSize()
+                                    .background(if (useBlur) tfBgColor.copy(alpha = 0.5f) else tfBgColor, RoundedCornerShape(tfCornerRadius.dp))
+                                )
+                                
+                                // Content Layer (Sharp)
+                                TextField(
+                                    value = message,
+                                    onValueChange = { message = it },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .focusRequester(focusRequester),
+                                    placeholder = { Text(androidx.compose.ui.res.stringResource(com.d4viddf.hyperbridge.R.string.reply_hint)) },
+                                    textStyle = androidx.compose.ui.text.TextStyle(color = txtColor),
+                                    colors = TextFieldDefaults.colors(
+                                        focusedContainerColor = Color.Transparent,
+                                        unfocusedContainerColor = Color.Transparent,
+                                        focusedIndicatorColor = Color.Transparent,
+                                        unfocusedIndicatorColor = Color.Transparent,
+                                        disabledContainerColor = Color.Transparent,
+                                        disabledIndicatorColor = Color.Transparent
+                                    ),
+                                    maxLines = 4,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                                    keyboardActions = KeyboardActions(
+                                        onSend = {
+                                            sendReply(pendingIntent, resultKey, message)
+                                        }
+                                    )
+                                )
+                            }
+                            
+                            Box(
+                                modifier = Modifier
+                                    .padding(start = 8.dp)
+                                    .size(56.dp)
+                                    .onGloballyPositioned { coords ->
+                                        val b = coords.boundsInWindow()
+                                        btnRect = android.graphics.Rect(b.left.toInt(), b.top.toInt(), b.right.toInt(), b.bottom.toInt())
+                                    }
+                            ) {
+                                // Background Layer
+                                Box(modifier = Modifier
+                                    .matchParentSize()
+                                    .background(if (useBlur) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f) else MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(btnCornerRadius.dp))
+                                )
+                                
+                                // Content Layer (Sharp)
+                                IconButton(
+                                    onClick = { sendReply(pendingIntent, resultKey, message) },
+                                    modifier = Modifier.fillMaxSize()
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Filled.Send,
+                                        contentDescription = "Send",
+                                        tint = if (message.isNotBlank()) sendParsedColor else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            setOnKeyListener { _, keyCode, event ->
+                if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                    removeOverlayAndStop()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+            WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH or
+            WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            PixelFormat.TRANSLUCENT
+        ).apply {
+            gravity = Gravity.CENTER
+            // We do NOT use FLAG_NOT_FOCUSABLE because we need the keyboard to open!
+            // But we must be careful to consume back presses to allow the user to exit.
+        }
+
+        try {
+            windowManager?.addView(composeView, params)
+        } catch (e: Exception) {
+            Log.e("InlineReplyService", "Failed to add overlay. SYSTEM_ALERT_WINDOW permission missing?", e)
+            stopSelf()
+        }
+    }
+
+    private fun sendReply(pendingIntent: PendingIntent, resultKey: String, message: String) {
+        if (message.isBlank()) return
+        
+        try {
+            val replyIntent = Intent()
+            val bundle = Bundle()
+            bundle.putCharSequence(resultKey, message)
+            
+            val remoteInput = RemoteInput.Builder(resultKey).build()
+            RemoteInput.addResultsToIntent(arrayOf(remoteInput), replyIntent, bundle)
+            
+            pendingIntent.send(this, 0, replyIntent)
+        } catch (e: PendingIntent.CanceledException) {
+            Log.e("InlineReplyService", "PendingIntent canceled", e)
+        }
+        
+        removeOverlayAndStop()
+    }
+
+    private fun removeOverlayAndStop() {
+        try {
+            composeView?.let { windowManager?.removeView(it) }
+        } catch (e: Exception) {
+            Log.e("InlineReplyService", "Failed to remove view", e)
+        }
+        composeView = null
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        removeOverlayAndStop()
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        store.clear()
+    }
+}

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/BaseTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/BaseTranslator.kt
@@ -1,6 +1,7 @@
 package com.d4viddf.hyperbridge.service.translators
 
 import android.app.Notification
+import android.app.PendingIntent
 import android.app.Person
 import android.content.Context
 import android.graphics.Bitmap
@@ -38,6 +39,7 @@ import io.github.d4viddf.hyperisland_kit.HyperAction
 import io.github.d4viddf.hyperisland_kit.HyperPicture
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
+import androidx.core.graphics.get
 
 abstract class BaseTranslator(
     protected val context: Context,
@@ -188,7 +190,7 @@ abstract class BaseTranslator(
 
         for (x in 0 until width step stepX) {
             for (y in 0 until height step stepY) {
-                val pixel = bitmap.getPixel(x, y)
+                val pixel = bitmap[x, y]
                 val alpha = Color.alpha(pixel)
                 if (alpha > 50) {
                     totalPixels++
@@ -264,10 +266,9 @@ abstract class BaseTranslator(
 
     protected fun extractBridgeActions(
         sbn: StatusBarNotification,
+        config: com.d4viddf.hyperbridge.models.IslandConfig,
         theme: HyperTheme? = null,
-        mode: ActionDisplayMode = ActionDisplayMode.BOTH,
-        hideReplies: Boolean = true,
-        useAppOpenForReplies: Boolean = false
+        mode: ActionDisplayMode = ActionDisplayMode.BOTH
     ): List<BridgeAction> {
         val bridgeActions = mutableListOf<BridgeAction>()
         val actions = sbn.notification.actions ?: return emptyList()
@@ -284,25 +285,29 @@ abstract class BaseTranslator(
 
         actions.forEachIndexed { index, androidAction ->
             val hasRemoteInput = androidAction.remoteInputs != null && androidAction.remoteInputs!!.isNotEmpty()
-            if (hasRemoteInput && hideReplies) return@forEachIndexed
-
             val rawTitle = androidAction.title?.toString() ?: ""
+            val isMarkAsRead = androidAction.semanticAction == Notification.Action.SEMANTIC_ACTION_MARK_AS_READ || rawTitle.equals("mark as read", ignoreCase = true)
+
+            if (config.removeOriginalNotification == true && (hasRemoteInput || isMarkAsRead)) {
+                return@forEachIndexed
+            }
+
             val uniqueKey = "act_${sbn.key.hashCode()}_$index"
 
-            val config = resolveActionConfig(theme, sbn.packageName, rawTitle)
+            val actionConfig = resolveActionConfig(theme, sbn.packageName, rawTitle)
 
-            val finalBgColorInt = if (config?.backgroundColor != null) {
+            val finalBgColorInt = if (actionConfig?.backgroundColor != null) {
                 try {
-                    config.backgroundColor.toColorInt()
+                    actionConfig.backgroundColor.toColorInt()
                 } catch(e: Exception) { defaultActionBg }
             } else {
                 defaultActionBg
             }
 
             val finalBgColorHex = String.format("#%08X", (0xFFFFFFFF and finalBgColorInt.toLong()))
-            val finalTintColorHex = config?.tintColor ?: "#FFFFFF"
+            val finalTintColorHex = actionConfig?.tintColor ?: "#FFFFFF"
 
-            val effectiveMode = when (config?.mode) {
+            val effectiveMode = when (actionConfig?.mode) {
                 ActionButtonMode.ICON -> ActionDisplayMode.ICON
                 ActionButtonMode.TEXT -> ActionDisplayMode.TEXT
                 ActionButtonMode.BOTH -> ActionDisplayMode.BOTH
@@ -316,7 +321,7 @@ abstract class BaseTranslator(
             val shouldLoadIcon = (effectiveMode != ActionDisplayMode.TEXT)
 
             var bitmapToUse: Bitmap? = null
-            val configIconRes = config?.icon
+            val configIconRes = actionConfig?.icon
             if (configIconRes != null && configIconRes.type == ResourceType.LOCAL_FILE && repository != null) {
                 bitmapToUse = repository.getResourceBitmap(configIconRes)
             }
@@ -340,8 +345,22 @@ abstract class BaseTranslator(
                 hyperPic = HyperPicture("${uniqueKey}_icon", processedBitmap)
             }
 
-            val finalIntent = if (hasRemoteInput && useAppOpenForReplies) {
-                sbn.notification.contentIntent ?: androidAction.actionIntent
+            val finalIntent = if (hasRemoteInput) {
+                if (config.enableInlineReply != false) {
+                    val replyIntent = android.content.Intent(context, com.d4viddf.hyperbridge.receiver.InlineReplyReceiver::class.java).apply {
+                        putExtra("pending_intent", androidAction.actionIntent)
+                        putExtra("result_key", androidAction.remoteInputs!![0].resultKey)
+                        putExtra("package_name", sbn.packageName)
+                    }
+                    PendingIntent.getBroadcast(
+                        context,
+                        uniqueKey.hashCode(),
+                        replyIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                    )
+                } else {
+                    sbn.notification.contentIntent ?: androidAction.actionIntent
+                }
             } else {
                 androidAction.actionIntent
             }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/DownloadTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/DownloadTranslator.kt
@@ -76,7 +76,7 @@ class DownloadTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
             }
         }
 
-        val actions = extractBridgeActions(sbn, theme)
+        val actions = extractBridgeActions(sbn, config, theme)
 
         builder.setChatInfo(
             title = title,

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
@@ -79,7 +79,7 @@ class ProgressTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
             }
         }
 
-        val actions = extractBridgeActions(sbn, theme)
+        val actions = extractBridgeActions(sbn, config, theme)
 
         builder.setChatInfo(
             title = title,

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/StandardTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/StandardTranslator.kt
@@ -59,9 +59,8 @@ class StandardTranslator(
 
         val bridgeActions = extractBridgeActions(
             sbn = sbn,
-            theme = theme,
-            hideReplies = false,
-            useAppOpenForReplies = true
+            config = config,
+            theme = theme
         )
 
         // Base Info (Shade)

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/TimerTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/TimerTranslator.kt
@@ -45,7 +45,7 @@ class TimerTranslator(context: Context, repo: ThemeRepository) : BaseTranslator(
         builder.addPicture(resolveIcon(sbn, picKey))
         builder.addPicture(getTransparentPicture(hiddenKey))
 
-        val actions = extractBridgeActions(sbn)
+        val actions = extractBridgeActions(sbn, config, theme)
 
         builder.setChatInfo(
             title = title,

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/components/IslandSettingsControl.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/components/IslandSettingsControl.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -224,11 +225,13 @@ fun IslandSettingsControl(
 
         Spacer(Modifier.height(8.dp))
 
+        val removeOriginalOn = displayConfig.removeOriginalNotification == true
+
         SettingsToggleCard(
             title = stringResource(R.string.remove_original_notification),
             subtitle = stringResource(R.string.remove_original_notification_desc),
             icon = Icons.Default.DeleteSweep,
-            checked = displayConfig.removeOriginalNotification ?: false,
+            checked = removeOriginalOn,
             onCheckedChange = { 
                 val currentIsFloat = config.isFloat ?: defaultConfig?.isFloat ?: true
                 onUpdate(config.copy(removeOriginalNotification = it, isFloat = currentIsFloat)) 
@@ -236,23 +239,46 @@ fun IslandSettingsControl(
             shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp, bottomStart = 4.dp, bottomEnd = 4.dp)
         )
 
-        // Only allow changing dismissWithOriginal if removeOriginalNotification is OFF
-        // (if it's ON, there's no original notification to dismiss with anyway).
-        val removeOriginalOn = displayConfig.removeOriginalNotification == true
-        SettingsToggleCard(
-            title = stringResource(R.string.dismiss_with_original),
-            subtitle = stringResource(R.string.dismiss_with_original_desc),
-            icon = Icons.Default.DeleteSweep, // Use appropriate icon, maybe same or another
-            checked = if (removeOriginalOn) true else (displayConfig.dismissWithOriginal ?: false),
-            enabled = !removeOriginalOn,
-            onCheckedChange = { 
-                if (!removeOriginalOn) {
-                    val currentIsFloat = config.isFloat ?: defaultConfig?.isFloat ?: true
-                    onUpdate(config.copy(dismissWithOriginal = it, isFloat = currentIsFloat)) 
+        Column {
+                SettingsToggleCard(
+                    title = stringResource(R.string.dismiss_with_original),
+                    subtitle = stringResource(R.string.dismiss_with_original_desc),
+                    icon = Icons.Default.DeleteSweep, 
+                    checked = displayConfig.dismissWithOriginal ?: false,
+                    enabled = !removeOriginalOn,
+                    onCheckedChange = { 
+                        val currentIsFloat = config.isFloat ?: defaultConfig?.isFloat ?: true
+                        onUpdate(config.copy(dismissWithOriginal = it, isFloat = currentIsFloat)) 
+                    },
+                    shape = RoundedCornerShape(4.dp)
+                )
+                
+                SettingsToggleCard(
+                    title = stringResource(R.string.enable_inline_reply),
+                    subtitle = stringResource(R.string.enable_inline_reply_desc),
+                    icon = Icons.AutoMirrored.Filled.Reply,
+                    checked = displayConfig.enableInlineReply ?: true,
+                    enabled = !removeOriginalOn,
+                    onCheckedChange = { 
+                        val currentIsFloat = config.isFloat ?: defaultConfig?.isFloat ?: true
+                        onUpdate(config.copy(enableInlineReply = it, isFloat = currentIsFloat)) 
+                    },
+                    shape = RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = if (removeOriginalOn) 4.dp else 24.dp, bottomEnd = if (removeOriginalOn) 4.dp else 24.dp)
+                )
+
+                AnimatedVisibility(
+                    visible = removeOriginalOn,
+                    enter = expandVertically(),
+                    exit = shrinkVertically()
+                ) {
+                    Text(
+                        text = stringResource(R.string.remove_original_notification_hidden_warning),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 16.dp)
+                    )
                 }
-            },
-            shape = RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp, bottomStart = 24.dp, bottomEnd = 24.dp)
-        )
+            }
     }
 }
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/navigation/NavGraph.kt
@@ -67,6 +67,7 @@ fun mainNavGraph(
         GlobalSettingsScreen(
             onBack = { navigator.goBack() },
             onNavSettingsClick = { navigator.navigate(Screen.NavCustomization(null)) },
+            onInlineReplyClick = { navigator.navigate(Screen.ReplyCustomization) },
             onIslandSettingsClick = { navigator.navigate(Screen.IslandSettings) },
             onEngineSettingsClick = { navigator.navigate(Screen.EngineSettings) },
             onDndSettingsClick = { navigator.navigate(Screen.DndSettings) },
@@ -78,6 +79,9 @@ fun mainNavGraph(
     }
     entry<Screen.PermanentIslandConfig> {
         com.d4viddf.hyperbridge.ui.screens.settings.PermanentIslandConfigScreen(onBack = { navigator.goBack() })
+    }
+    entry<Screen.ReplyCustomization> {
+        com.d4viddf.hyperbridge.ui.screens.theme.GlobalReplyCustomizationScreen(onBack = { navigator.goBack() })
     }
     entry<Screen.NavCustomization> { key ->
         NavCustomizationScreen(

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/navigation/Screen.kt
@@ -24,4 +24,5 @@ sealed interface Screen : NavKey {
     @Serializable data object IslandSettings : Screen
     @Serializable data object DndSettings : Screen
     @Serializable data object PermanentIslandConfig : Screen
+    @Serializable data object ReplyCustomization : Screen
 }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/onboarding/OnboardingScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Architecture
 import androidx.compose.material.icons.filled.BatteryStd
+import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Construction
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Info
@@ -627,6 +628,7 @@ fun BehaviorConfigPage(prefs: AppPreferences) {
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             val removeOriginalOn = config.removeOriginalNotification == true
+            
             ListOptionCard(
                 title = stringResource(R.string.remove_original_notification),
                 subtitle = stringResource(R.string.remove_original_notification_desc),
@@ -642,26 +644,62 @@ fun BehaviorConfigPage(prefs: AppPreferences) {
                 }
             )
 
-            ListOptionCard(
-                title = stringResource(R.string.dismiss_with_original),
-                subtitle = stringResource(R.string.dismiss_with_original_desc),
-                icon = Icons.Default.DeleteSweep,
-                shape = RoundedCornerShape(4.dp),
-                onClick = {
-                    if (!removeOriginalOn) {
-                        scope.launch {
-                            prefs.updateGlobalConfig(config.copy(dismissWithOriginal = !(config.dismissWithOriginal ?: false)))
+            AnimatedVisibility(
+                visible = removeOriginalOn,
+                enter = expandVertically(),
+                exit = shrinkVertically()
+            ) {
+                Text(
+                    text = stringResource(R.string.remove_original_notification_hidden_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+            }
+
+            AnimatedVisibility(
+                visible = !removeOriginalOn,
+                enter = expandVertically(),
+                exit = shrinkVertically()
+            ) {
+                Column {
+                    ListOptionCard(
+                        title = stringResource(R.string.dismiss_with_original),
+                        subtitle = stringResource(R.string.dismiss_with_original_desc),
+                        icon = Icons.Default.DeleteSweep,
+                        shape = RoundedCornerShape(4.dp),
+                        onClick = {
+                            scope.launch {
+                                prefs.updateGlobalConfig(config.copy(dismissWithOriginal = !(config.dismissWithOriginal ?: false)))
+                            }
+                        },
+                        trailingContent = {
+                            Checkbox(
+                                checked = config.dismissWithOriginal ?: false,
+                                onCheckedChange = null
+                            )
                         }
-                    }
-                },
-                trailingContent = {
-                    Checkbox(
-                        checked = if (removeOriginalOn) true else (config.dismissWithOriginal ?: false),
-                        enabled = !removeOriginalOn,
-                        onCheckedChange = null
+                    )
+
+                    ListOptionCard(
+                        title = stringResource(R.string.enable_inline_reply),
+                        subtitle = stringResource(R.string.enable_inline_reply_desc),
+                        icon = Icons.AutoMirrored.Filled.Reply,
+                        shape = RoundedCornerShape(4.dp),
+                        onClick = {
+                            scope.launch {
+                                prefs.updateGlobalConfig(config.copy(enableInlineReply = !(config.enableInlineReply ?: true)))
+                            }
+                        },
+                        trailingContent = {
+                            Checkbox(
+                                checked = config.enableInlineReply ?: true,
+                                onCheckedChange = null
+                            )
+                        }
                     )
                 }
-            )
+            }
 
             ListOptionCard(
                 title = stringResource(R.string.config_shade_title),

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalSettingsScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/GlobalSettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.DisplaySettings
 import androidx.compose.material.icons.outlined.DoNotDisturbOn
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material.icons.outlined.Navigation
 import androidx.compose.material.icons.outlined.PushPin
@@ -46,6 +47,7 @@ import com.d4viddf.hyperbridge.ui.screens.theme.getExpressiveShape
 fun GlobalSettingsScreen(
     onBack: () -> Unit,
     onNavSettingsClick: () -> Unit,
+    onInlineReplyClick: () -> Unit,
     onIslandSettingsClick: () -> Unit,
     onEngineSettingsClick: () -> Unit,
     onDndSettingsClick: () -> Unit,
@@ -74,7 +76,7 @@ fun GlobalSettingsScreen(
                 title = stringResource(R.string.engine),
                 subtitle = stringResource(R.string.engine_desc),
                 icon = Icons.Outlined.Memory,
-                shape = getExpressiveShape(5, 0, ShapeStyle.Large),
+                shape = getExpressiveShape(6, 0, ShapeStyle.Large),
                 onClick = onEngineSettingsClick
             )
             Spacer(Modifier.height(2.dp))
@@ -82,7 +84,7 @@ fun GlobalSettingsScreen(
                 title = stringResource(R.string.island_behavior_title),
                 subtitle = stringResource(R.string.island_behavior_desc),
                 icon = Icons.Outlined.DisplaySettings,
-                shape = getExpressiveShape(5, 1, ShapeStyle.Large),
+                shape = getExpressiveShape(6, 1, ShapeStyle.Large),
                 onClick = onIslandSettingsClick
             )
             Spacer(Modifier.height(2.dp))
@@ -90,7 +92,7 @@ fun GlobalSettingsScreen(
                 title = stringResource(R.string.dnd_mode_title),
                 subtitle = stringResource(R.string.dnd_mode_desc),
                 icon = Icons.Outlined.DoNotDisturbOn,
-                shape = getExpressiveShape(5, 2, ShapeStyle.Large),
+                shape = getExpressiveShape(6, 2, ShapeStyle.Large),
                 onClick = onDndSettingsClick
             )
             Spacer(Modifier.height(2.dp))
@@ -98,15 +100,23 @@ fun GlobalSettingsScreen(
                 title = stringResource(R.string.nav_layout_title),
                 subtitle = stringResource(R.string.nav_layout_desc),
                 icon = Icons.Outlined.Navigation,
-                shape = getExpressiveShape(5, 3, ShapeStyle.Large),
+                shape = getExpressiveShape(6, 3, ShapeStyle.Large),
                 onClick = onNavSettingsClick
+            )
+            Spacer(Modifier.height(2.dp))
+            ListOptionCard(
+                title = stringResource(R.string.inline_reply_title),
+                subtitle = stringResource(R.string.customize_inline_reply),
+                icon = Icons.Outlined.Edit,
+                shape = getExpressiveShape(6, 4, ShapeStyle.Large),
+                onClick = onInlineReplyClick
             )
             Spacer(Modifier.height(2.dp))
             ListOptionCard(
                 title = stringResource(R.string.permanent_island_title),
                 subtitle = stringResource(R.string.permanent_island_desc),
                 icon = Icons.Outlined.PushPin,
-                shape = getExpressiveShape(5, 4, ShapeStyle.Large),
+                shape = getExpressiveShape(6, 5, ShapeStyle.Large),
                 onClick = onPermanentIslandClick
             )
             Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/AppThemeEditorScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/AppThemeEditorScreen.kt
@@ -77,7 +77,7 @@ import com.d4viddf.hyperbridge.ui.screens.theme.content.safeParseColor
 import com.d4viddf.hyperbridge.ui.theme.HyperBridgeTheme
 
 enum class AppEditorRoute {
-    MENU, BEHAVIOR_MENU, BEHAVIOR_ENGINE, BEHAVIOR_ISLAND, BEHAVIOR_TYPES, COLORS, ICONS, CALLS, NAVIGATION, ACTIONS
+    MENU, BEHAVIOR_MENU, BEHAVIOR_ENGINE, BEHAVIOR_ISLAND, BEHAVIOR_TYPES, COLORS, ICONS, CALLS, NAVIGATION, REPLY, ACTIONS
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -118,6 +118,7 @@ fun AppThemeEditor(viewModel: ThemeViewModel) {
                                     AppEditorRoute.ICONS -> R.string.creator_nav_icons
                                     AppEditorRoute.CALLS -> R.string.creator_nav_calls
                                     AppEditorRoute.NAVIGATION -> R.string.nav_layout_title
+                                    AppEditorRoute.REPLY -> R.string.app_name // Fallback or explicit string if preferred
                                     AppEditorRoute.ACTIONS -> R.string.creator_nav_actions
                                     else -> R.string.app_name
                                 }
@@ -128,6 +129,12 @@ fun AppThemeEditor(viewModel: ThemeViewModel) {
                         if (currentRoute == AppEditorRoute.MENU) {
                             Text(
                                 text = viewModel.editingAppLabel,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        } else if (currentRoute == AppEditorRoute.REPLY) {
+                            Text(
+                                text = "Inline Reply",
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.primary
                             )
@@ -232,6 +239,9 @@ fun AppThemeEditor(viewModel: ThemeViewModel) {
                             showTopBar = false
                         )
                     }
+                    AppEditorRoute.REPLY -> Box(Modifier.fillMaxSize()) {
+                        com.d4viddf.hyperbridge.ui.screens.theme.content.ReplyStyleSheetContent(viewModel = viewModel)
+                    }
                     AppEditorRoute.ACTIONS -> Box(Modifier.fillMaxSize()) {
                         AppActionEditor(viewModel)
                     }
@@ -319,6 +329,7 @@ fun AppEditorMenu(
                 AppEditorRoute.ICONS,
                 AppEditorRoute.CALLS,
                 AppEditorRoute.NAVIGATION,
+                AppEditorRoute.REPLY,
                 AppEditorRoute.ACTIONS
             )
 
@@ -364,6 +375,13 @@ fun AppEditorMenu(
                         title = stringResource(R.string.nav_layout_title),
                         subtitle = stringResource(R.string.nav_layout_desc),
                         icon = Icons.Outlined.Map,
+                        shape = shape,
+                        onClick = { onNavigate(route) }
+                    )
+                    AppEditorRoute.REPLY -> CreatorOptionCard(
+                        title = stringResource(R.string.inline_reply_title),
+                        subtitle = stringResource(R.string.customize_inline_reply),
+                        icon = Icons.Outlined.Call, // Just use a call or generic icon for now
                         shape = shape,
                         onClick = { onNavigate(route) }
                     )

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/GlobalReplyCustomizationScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/GlobalReplyCustomizationScreen.kt
@@ -1,0 +1,69 @@
+package com.d4viddf.hyperbridge.ui.screens.theme
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.ui.screens.theme.content.ReplyStyleSheetContent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GlobalReplyCustomizationScreen(
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val viewModel: ThemeViewModel = viewModel()
+    val activeThemeId by viewModel.activeThemeId.collectAsState()
+    
+    LaunchedEffect(activeThemeId) {
+        if (activeThemeId != null) {
+            viewModel.loadThemeForEditing(activeThemeId!!)
+        } else {
+            viewModel.clearCreatorState()
+        }
+    }
+
+    BackHandler {
+        viewModel.saveTheme(existingId = viewModel.currentEditingThemeId, apply = true)
+        onBack()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.inline_reply_title)) },
+                navigationIcon = {
+                    FilledTonalIconButton(onClick = {
+                        viewModel.saveTheme(existingId = viewModel.currentEditingThemeId, apply = true)
+                        onBack()
+                    }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding).fillMaxSize()) {
+            if (viewModel.currentEditingThemeId != null) {
+                ReplyStyleSheetContent(viewModel = viewModel)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/ThemeCreatorScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/ThemeCreatorScreen.kt
@@ -109,7 +109,7 @@ import kotlinx.coroutines.withContext
 
 // [NEW] Sub-menu routing added
 enum class CreatorRoute {
-    MAIN_MENU, BEHAVIOR_MENU, BEHAVIOR_ENGINE, BEHAVIOR_ISLAND, BEHAVIOR_TYPES, COLORS, ICONS, CALLS, NAVIGATION, ACTIONS, APPS
+    MAIN_MENU, BEHAVIOR_MENU, BEHAVIOR_ENGINE, BEHAVIOR_ISLAND, BEHAVIOR_TYPES, COLORS, ICONS, CALLS, NAVIGATION, REPLY, ACTIONS, APPS
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -187,6 +187,7 @@ fun ThemeCreatorScreen(
                                 CreatorRoute.ICONS -> stringResource(R.string.creator_nav_icons)
                                 CreatorRoute.CALLS -> stringResource(R.string.creator_nav_calls)
                                 CreatorRoute.NAVIGATION -> stringResource(R.string.nav_layout_title)
+                                CreatorRoute.REPLY -> stringResource(R.string.inline_reply_title)
                                 CreatorRoute.ACTIONS -> stringResource(R.string.creator_nav_actions)
                                 CreatorRoute.APPS -> stringResource(R.string.creator_nav_apps)
                             },
@@ -260,6 +261,9 @@ fun ThemeCreatorScreen(
                         }
                         CreatorRoute.NAVIGATION -> Box(Modifier.fillMaxSize()) {
                             NavCustomizationScreen(onBack = { currentRoute = CreatorRoute.MAIN_MENU },null, false)
+                        }
+                        CreatorRoute.REPLY -> Box(Modifier.fillMaxSize()) {
+                            com.d4viddf.hyperbridge.ui.screens.theme.content.ReplyStyleSheetContent(viewModel = viewModel)
                         }
                         CreatorRoute.COLORS -> DetailScreenShell(
                             previewContent = {
@@ -416,6 +420,7 @@ fun CreatorMainList(viewModel: ThemeViewModel, onNavigate: (CreatorRoute) -> Uni
                 CreatorRoute.ICONS,
                 CreatorRoute.CALLS,
                 CreatorRoute.NAVIGATION,
+                CreatorRoute.REPLY,
                 CreatorRoute.ACTIONS,
                 CreatorRoute.APPS
             )
@@ -433,6 +438,7 @@ fun CreatorMainList(viewModel: ThemeViewModel, onNavigate: (CreatorRoute) -> Uni
                         CreatorRoute.ICONS -> Icons.Outlined.Widgets
                         CreatorRoute.CALLS -> Icons.Outlined.Call
                         CreatorRoute.NAVIGATION -> Icons.Outlined.Map
+                        CreatorRoute.REPLY -> Icons.Outlined.Edit
                         CreatorRoute.ACTIONS -> Icons.Outlined.TouchApp
                         CreatorRoute.APPS -> Icons.Outlined.Apps
                         else -> Icons.Outlined.Image
@@ -443,6 +449,7 @@ fun CreatorMainList(viewModel: ThemeViewModel, onNavigate: (CreatorRoute) -> Uni
                         CreatorRoute.ICONS -> stringResource(R.string.creator_nav_icons)
                         CreatorRoute.CALLS -> stringResource(R.string.creator_nav_calls)
                         CreatorRoute.NAVIGATION -> stringResource(R.string.nav_layout_title)
+                        CreatorRoute.REPLY -> stringResource(R.string.inline_reply_title)
                         CreatorRoute.ACTIONS -> stringResource(R.string.creator_nav_actions)
                         CreatorRoute.APPS -> stringResource(R.string.creator_nav_apps)
                         else -> stringResource(R.string.app_name)
@@ -453,6 +460,7 @@ fun CreatorMainList(viewModel: ThemeViewModel, onNavigate: (CreatorRoute) -> Uni
                         CreatorRoute.ICONS -> stringResource(R.string.creator_sub_icons)
                         CreatorRoute.CALLS -> stringResource(R.string.creator_sub_calls)
                         CreatorRoute.NAVIGATION -> stringResource(R.string.nav_layout_desc)
+                        CreatorRoute.REPLY -> stringResource(R.string.customize_inline_reply)
                         CreatorRoute.ACTIONS -> stringResource(R.string.creator_sub_actions)
                         CreatorRoute.APPS -> stringResource(R.string.creator_sub_apps)
                         else -> stringResource(R.string.app_name)

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/ThemeViewModel.kt
@@ -112,6 +112,28 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     var appUseNativeLiveUpdates by mutableStateOf<Boolean?>(null)
     var appEnabledNotificationTypes by mutableStateOf<Set<String>?>(null)
 
+    // GLOBAL REPLY SETTINGS
+    var replyBackgroundColor by mutableStateOf<String?>(null)
+    var replySendIconUri by mutableStateOf<Uri?>(null)
+    var replySendColor by mutableStateOf<String?>(null)
+    var replyTextfieldBackgroundColor by mutableStateOf<String?>(null)
+    var replyTextColor by mutableStateOf<String?>(null)
+    var replyColorMode by mutableStateOf<ColorMode?>(null)
+    var replyUseBlur by mutableStateOf(false)
+    var replyTextfieldCornerRadius by mutableIntStateOf(24)
+    var replySendButtonCornerRadius by mutableIntStateOf(24)
+
+    // APP-SPECIFIC REPLY SETTINGS
+    var appReplyBackgroundColor by mutableStateOf<String?>(null)
+    var appReplySendIconUri by mutableStateOf<Uri?>(null)
+    var appReplySendColor by mutableStateOf<String?>(null)
+    var appReplyTextfieldBackgroundColor by mutableStateOf<String?>(null)
+    var appReplyTextColor by mutableStateOf<String?>(null)
+    var appReplyColorMode by mutableStateOf<ColorMode?>(null)
+    var appReplyUseBlur by mutableStateOf<Boolean?>(null)
+    var appReplyTextfieldCornerRadius by mutableStateOf<Int?>(null)
+    var appReplySendButtonCornerRadius by mutableStateOf<Int?>(null)
+
     private val _tempAssets = java.util.concurrent.ConcurrentHashMap<String, Uri>()
 
     val shareTheme: String = application.getString(R.string.share_theme)
@@ -239,6 +261,16 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
 
         appUseNativeLiveUpdates = override?.useNativeLiveUpdates
         appEnabledNotificationTypes = override?.activeNotificationTypes
+
+        appReplyBackgroundColor = override?.replyConfig?.backgroundColor
+        appReplySendIconUri = null
+        appReplySendColor = override?.replyConfig?.sendColor
+        appReplyTextfieldBackgroundColor = override?.replyConfig?.textfieldBackgroundColor
+        appReplyTextColor = override?.replyConfig?.textColor
+        appReplyColorMode = override?.replyConfig?.colorMode
+        appReplyUseBlur = override?.replyConfig?.useBlur
+        appReplyTextfieldCornerRadius = override?.replyConfig?.textfieldCornerRadius
+        appReplySendButtonCornerRadius = override?.replyConfig?.sendButtonCornerRadius
     }
 
     fun saveAppChanges() {
@@ -269,6 +301,31 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
             )
         } else existingOverride?.callConfig // [FIX] Prevent existing call configs from being wiped if only Live Updates were changed!
 
+        val hasReplyChanges = appReplyBackgroundColor != null || appReplySendColor != null ||
+                appReplyTextfieldBackgroundColor != null || appReplyColorMode != null ||
+                appReplyTextColor != null ||
+                appReplyUseBlur != null ||
+                appReplyTextfieldCornerRadius != null || appReplySendButtonCornerRadius != null
+
+        val replyModule = if (hasReplyChanges) {
+            val existing = existingOverride?.replyConfig
+            com.d4viddf.hyperbridge.models.theme.ReplyModule(
+                backgroundColor = appReplyBackgroundColor ?: existing?.backgroundColor,
+                sendColor = appReplySendColor ?: existing?.sendColor,
+                textfieldBackgroundColor = appReplyTextfieldBackgroundColor ?: existing?.textfieldBackgroundColor,
+                textColor = appReplyTextColor ?: existing?.textColor,
+                colorMode = appReplyColorMode ?: existing?.colorMode,
+                useBlur = appReplyUseBlur ?: existing?.useBlur ?: false,
+                textfieldCornerRadius = appReplyTextfieldCornerRadius ?: existing?.textfieldCornerRadius ?: 24,
+                sendButtonCornerRadius = appReplySendButtonCornerRadius ?: existing?.sendButtonCornerRadius ?: 24,
+                sendIcon = if (appReplySendIconUri != null) {
+                    val key = "app_${pkg}_reply_send"
+                    stageAsset(key, appReplySendIconUri!!)
+                    ThemeResource(ResourceType.LOCAL_FILE, "icons/$key.png")
+                } else existing?.sendIcon
+            )
+        } else existingOverride?.replyConfig
+
         val newOverride = AppThemeOverride(
             highlightColor = appHighlightColor,
             useAppColors = appColorMode?.let { it == ColorMode.APP_ICON },
@@ -279,6 +336,7 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
             actions = appActions.ifEmpty { null },
             progress = existingOverride?.progress,
             navigation = existingOverride?.navigation,
+            replyConfig = replyModule,
             useNativeLiveUpdates = appUseNativeLiveUpdates,
             activeNotificationTypes = appEnabledNotificationTypes
         )
@@ -323,6 +381,16 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
             // [FIX] Load the global engine selection
             themeUseNativeLiveUpdates = theme.global.useNativeLiveUpdates
 
+            replyBackgroundColor = theme.defaultReply.backgroundColor
+            replySendIconUri = null
+            replySendColor = theme.defaultReply.sendColor
+            replyTextfieldBackgroundColor = theme.defaultReply.textfieldBackgroundColor
+            replyTextColor = theme.defaultReply.textColor
+            replyColorMode = theme.defaultReply.colorMode ?: ColorMode.CUSTOM
+            replyUseBlur = theme.defaultReply.useBlur
+            replyTextfieldCornerRadius = theme.defaultReply.textfieldCornerRadius
+            replySendButtonCornerRadius = theme.defaultReply.sendButtonCornerRadius
+
             _appOverrides.value = theme.apps
             themeDefaultActions = theme.defaultActions
         }
@@ -351,6 +419,16 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
 
         // [FIX] Reset to null instead of false
         themeUseNativeLiveUpdates = null
+
+        replyBackgroundColor = null
+        replySendIconUri = null
+        replySendColor = null
+        replyTextfieldBackgroundColor = null
+        replyTextColor = null
+        replyColorMode = ColorMode.CUSTOM
+        replyUseBlur = false
+        replyTextfieldCornerRadius = 24
+        replySendButtonCornerRadius = 24
 
         appHighlightColor = null
         appColorMode = null
@@ -453,6 +531,21 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
                         declineColor = callDeclineColor,
                         answerShapeId = callAnswerShapeId,
                         declineShapeId = callDeclineShapeId
+                    ),
+                    defaultReply = com.d4viddf.hyperbridge.models.theme.ReplyModule(
+                        backgroundColor = replyBackgroundColor,
+                        sendColor = replySendColor,
+                        textfieldBackgroundColor = replyTextfieldBackgroundColor,
+                        textColor = replyTextColor,
+                        colorMode = replyColorMode,
+                        useBlur = replyUseBlur,
+                        textfieldCornerRadius = replyTextfieldCornerRadius,
+                        sendButtonCornerRadius = replySendButtonCornerRadius,
+                        sendIcon = if (replySendIconUri != null) {
+                            val key = "theme_reply_send"
+                            stageAsset(key, replySendIconUri!!)
+                            ThemeResource(ResourceType.LOCAL_FILE, "icons/$key.png")
+                        } else getThemeById(themeId)?.defaultReply?.sendIcon
                     ),
                     defaultActions = themeDefaultActions,
                     apps = _appOverrides.value

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/content/ReplyStyleSheetContent.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/theme/content/ReplyStyleSheetContent.kt
@@ -1,0 +1,452 @@
+package com.d4viddf.hyperbridge.ui.screens.theme.content
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.DisplaySettings
+import androidx.compose.material.icons.outlined.Palette
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.d4viddf.hyperbridge.R
+import com.d4viddf.hyperbridge.models.theme.ColorMode
+import com.d4viddf.hyperbridge.ui.components.CustomColorBottomSheet
+import com.d4viddf.hyperbridge.ui.screens.theme.ThemeViewModel
+import dev.chrisbanes.haze.haze
+import dev.chrisbanes.haze.hazeChild
+
+@OptIn(ExperimentalMaterial3Api::class, androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ReplyStyleSheetContent(viewModel: ThemeViewModel) {
+    val isAppOverride = viewModel.editingAppPackage != null
+
+    val backgroundColor = if (isAppOverride) viewModel.appReplyBackgroundColor else viewModel.replyBackgroundColor
+    val sendColor = if (isAppOverride) viewModel.appReplySendColor else viewModel.replySendColor
+    val textfieldBackgroundColor = if (isAppOverride) viewModel.appReplyTextfieldBackgroundColor else viewModel.replyTextfieldBackgroundColor
+    val textColor = if (isAppOverride) viewModel.appReplyTextColor else viewModel.replyTextColor
+    val colorMode = if (isAppOverride) viewModel.appReplyColorMode ?: ColorMode.DEFAULT else viewModel.replyColorMode ?: ColorMode.DEFAULT
+    val useBlur = if (isAppOverride) viewModel.appReplyUseBlur ?: false else viewModel.replyUseBlur
+    val textfieldCornerRadius = if (isAppOverride) viewModel.appReplyTextfieldCornerRadius ?: 24 else viewModel.replyTextfieldCornerRadius
+    val sendButtonCornerRadius = if (isAppOverride) viewModel.appReplySendButtonCornerRadius ?: 24 else viewModel.replySendButtonCornerRadius
+
+    var tabIndex by remember { androidx.compose.runtime.mutableIntStateOf(0) }
+
+    androidx.compose.material3.Scaffold(
+        containerColor = Color.Transparent,
+        floatingActionButtonPosition = androidx.compose.material3.FabPosition.Center,
+        floatingActionButton = {
+            androidx.compose.material3.HorizontalFloatingToolbar(
+                expanded = true,
+                content = {
+                    Row(
+                        modifier = Modifier.wrapContentWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        com.d4viddf.hyperbridge.ui.screens.design.ToolbarOption(
+                            selected = tabIndex == 0,
+                            icon = Icons.Outlined.Palette,
+                            text = stringResource(R.string.creator_nav_colors),
+                            onClick = { tabIndex = 0 }
+                        )
+
+                        com.d4viddf.hyperbridge.ui.screens.design.ToolbarOption(
+                            selected = tabIndex == 1,
+                            icon = Icons.Outlined.DisplaySettings,
+                            text = stringResource(R.string.reply_appearance),
+                            onClick = { tabIndex = 1 }
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = paddingValues.calculateBottomPadding())
+                .padding(bottom = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            // Preview Header pushed above the bottom surface
+            Box(modifier = Modifier.weight(1f).padding(top = 16.dp), contentAlignment = Alignment.TopCenter) {
+                InlineReplyPreview(
+                    isDarkThemePreview = viewModel.isDarkThemePreview,
+                    isMaterialYou = colorMode == ColorMode.MATERIAL_YOU,
+                    useBlur = useBlur,
+                    textfieldCornerRadius = textfieldCornerRadius,
+                    sendButtonCornerRadius = sendButtonCornerRadius,
+                    textfieldBackgroundColorHex = textfieldBackgroundColor,
+                    textColorHex = textColor,
+                    sendColorHex = sendColor
+                )
+            }
+
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 100.dp)
+                    .animateContentSize(alignment = Alignment.BottomCenter),
+                shape = RoundedCornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer
+            ) {
+                androidx.compose.animation.AnimatedContent(
+                    targetState = tabIndex,
+                    transitionSpec = { fadeIn() togetherWith fadeOut() },
+                    label = "ReplyTabsTransition",
+                    modifier = Modifier.padding(vertical = 12.dp)
+                ) { selectedTab ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState())
+                            .padding(bottom = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (selectedTab == 0) {
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = colorMode == ColorMode.CUSTOM,
+                                enter = androidx.compose.animation.expandVertically(expandFrom = Alignment.Bottom) + fadeIn(),
+                                exit = androidx.compose.animation.shrinkVertically(shrinkTowards = Alignment.Bottom) + fadeOut()
+                            ) {
+                                Column {
+                                    Text(
+                                        text = stringResource(R.string.color_mode_custom),
+                                        style = MaterialTheme.typography.titleMedium,
+                                        modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+                                    )
+                                    val isColorsEnabled = !useBlur
+                                    ColorPickerSetting(stringResource(R.string.reply_textfield_color), stringResource(R.string.reply_textfield_color_desc), textfieldBackgroundColor, defaultColor = MaterialTheme.colorScheme.surfaceVariant, enabled = isColorsEnabled, onReset = { if (isAppOverride) viewModel.appReplyTextfieldBackgroundColor = null else viewModel.replyTextfieldBackgroundColor = null }) { 
+                                        if (isAppOverride) viewModel.appReplyTextfieldBackgroundColor = it else viewModel.replyTextfieldBackgroundColor = it 
+                                    }
+                                    ColorPickerSetting(stringResource(R.string.reply_text_color), stringResource(R.string.reply_text_color_desc), textColor, defaultColor = MaterialTheme.colorScheme.onSurface, enabled = true, onReset = { if (isAppOverride) viewModel.appReplyTextColor = null else viewModel.replyTextColor = null }) { 
+                                        if (isAppOverride) viewModel.appReplyTextColor = it else viewModel.replyTextColor = it 
+                                    }
+                                    ColorPickerSetting(stringResource(R.string.reply_send_color), stringResource(R.string.reply_send_color_desc), sendColor, defaultColor = MaterialTheme.colorScheme.primary, enabled = true, onReset = { if (isAppOverride) viewModel.appReplySendColor = null else viewModel.replySendColor = null }) { 
+                                        if (isAppOverride) viewModel.appReplySendColor = it else viewModel.replySendColor = it 
+                                    }
+                                    
+                                    androidx.compose.material3.HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outlineVariant,
+                                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                    )
+                                }
+                            }
+
+                            Text(
+                                text = stringResource(R.string.color_mode),
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+                            )
+                            
+                            var showColorModeSheet by remember { mutableStateOf(false) }
+                            val modeText = when (colorMode) {
+                                ColorMode.DEFAULT -> stringResource(R.string.color_mode_default)
+                                ColorMode.APP_ICON -> stringResource(R.string.color_mode_app)
+                                ColorMode.MATERIAL_YOU -> stringResource(R.string.color_mode_material)
+                                ColorMode.CUSTOM -> stringResource(R.string.color_mode_custom)
+                            }
+                            
+                            ListItem(
+                                headlineContent = { Text(stringResource(R.string.color_mode)) },
+                                supportingContent = { Text(modeText) },
+                                modifier = Modifier
+                                    .clickable(role = androidx.compose.ui.semantics.Role.DropdownList) { showColorModeSheet = true },
+                                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                trailingContent = {
+                                    Icon(
+                                        imageVector = Icons.Default.ArrowDropDown,
+                                        contentDescription = stringResource(R.string.color_mode_change_cd)
+                                    )
+                                }
+                            )
+                            
+                            if (showColorModeSheet) {
+                                androidx.compose.material3.ModalBottomSheet(
+                                    onDismissRequest = { showColorModeSheet = false },
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                                ) {
+                                    Column(modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)) {
+                                        Text(stringResource(R.string.color_mode_select), style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(16.dp))
+                                        ColorMode.entries.forEach { mode ->
+                                            val label = when (mode) {
+                                                ColorMode.DEFAULT -> stringResource(R.string.color_mode_default)
+                                                ColorMode.APP_ICON -> stringResource(R.string.color_mode_app)
+                                                ColorMode.MATERIAL_YOU -> stringResource(R.string.color_mode_material)
+                                                ColorMode.CUSTOM -> stringResource(R.string.color_mode_custom)
+                                            }
+                                            val desc = when (mode) {
+                                                ColorMode.DEFAULT -> stringResource(R.string.color_mode_default_desc)
+                                                ColorMode.APP_ICON -> stringResource(R.string.color_mode_app_desc)
+                                                ColorMode.MATERIAL_YOU -> stringResource(R.string.color_mode_material_desc)
+                                                ColorMode.CUSTOM -> stringResource(R.string.color_mode_custom_desc)
+                                            }
+                                            ListItem(
+                                                headlineContent = { Text(label) },
+                                                supportingContent = { Text(desc) },
+                                                modifier = Modifier.clickable {
+                                                    if (isAppOverride) viewModel.appReplyColorMode = mode else viewModel.replyColorMode = mode
+                                                    showColorModeSheet = false
+                                                },
+                                                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                                trailingContent = {
+                                                    if (colorMode == mode) {
+                                                        Icon(Icons.Default.Check, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            Text(
+                                text = stringResource(R.string.reply_appearance),
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+                            )
+                            ListItem(
+                                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                headlineContent = { Text(stringResource(R.string.reply_blur_effect)) },
+                                supportingContent = { Text(stringResource(R.string.reply_blur_effect_desc)) },
+                                trailingContent = { Switch(checked = useBlur, onCheckedChange = { if (isAppOverride) viewModel.appReplyUseBlur = it else viewModel.replyUseBlur = it }) }
+                            )
+                            SliderSetting(stringResource(R.string.reply_textfield_radius), textfieldCornerRadius.toFloat(), 0f..64f) { 
+                                if (isAppOverride) viewModel.appReplyTextfieldCornerRadius = it.toInt() else viewModel.replyTextfieldCornerRadius = it.toInt() 
+                            }
+                            SliderSetting(stringResource(R.string.reply_send_radius), sendButtonCornerRadius.toFloat(), 0f..64f) { 
+                                if (isAppOverride) viewModel.appReplySendButtonCornerRadius = it.toInt() else viewModel.replySendButtonCornerRadius = it.toInt() 
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ColorPickerSetting(title: String, subtitle: String, colorHex: String?, defaultColor: Color, enabled: Boolean = true, onReset: (() -> Unit)? = null, onColorChanged: (String) -> Unit) {
+    var showColorPicker by remember { mutableStateOf(false) }
+    val color = colorHex?.let { safeParseColor(it) } ?: defaultColor
+    
+    ListItem(
+        headlineContent = { Text(title) },
+        supportingContent = { Text(subtitle) },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (onReset != null && colorHex != null) {
+                    IconButton(onClick = onReset, modifier = Modifier.size(32.dp)) {
+                        Icon(Icons.Filled.Close, contentDescription = "Reset", modifier = Modifier.size(20.dp))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .background(if (enabled) color else color.copy(alpha = 0.38f))
+                        .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
+                )
+            }
+        },
+        modifier = Modifier.clickable(enabled = enabled) { showColorPicker = true },
+        colors = ListItemDefaults.colors(
+            containerColor = Color.Transparent,
+            headlineColor = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            supportingColor = if (enabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+        )
+    )
+    
+    if (showColorPicker) {
+        CustomColorBottomSheet(
+            initialColor = color,
+            onDismiss = { showColorPicker = false },
+            onColorAdded = { newColor ->
+                val hex = String.format("#%08X", newColor.toArgb())
+                onColorChanged(hex)
+                showColorPicker = false
+            }
+        )
+    }
+}
+
+@Composable
+fun SliderSetting(title: String, value: Float, range: ClosedFloatingPointRange<Float>, onValueChange: (Float) -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(title)
+            Text(value.toInt().toString())
+        }
+        Slider(value = value, onValueChange = onValueChange, valueRange = range)
+    }
+}
+
+@Composable
+fun InlineReplyPreview(
+    isDarkThemePreview: Boolean,
+    isMaterialYou: Boolean,
+    useBlur: Boolean,
+    textfieldCornerRadius: Int,
+    sendButtonCornerRadius: Int,
+    textfieldBackgroundColorHex: String?,
+    textColorHex: String?,
+    sendColorHex: String?
+) {
+    val tfBgColor = if (isMaterialYou) MaterialTheme.colorScheme.surfaceVariant else (textfieldBackgroundColorHex?.let { safeParseColor(it) } ?: MaterialTheme.colorScheme.surfaceVariant)
+    val sendColor = if (isMaterialYou) MaterialTheme.colorScheme.primary else (sendColorHex?.let { safeParseColor(it) } ?: MaterialTheme.colorScheme.primary)
+    val txtColor = if (isMaterialYou) MaterialTheme.colorScheme.onSurface else (textColorHex?.let { safeParseColor(it) } ?: MaterialTheme.colorScheme.onSurface)
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(horizontal = 16.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+        contentAlignment = Alignment.Center
+    ) {
+        val hazeState = remember { dev.chrisbanes.haze.HazeState() }
+        
+        // A placeholder background simulating screen content
+        Box(modifier = Modifier
+            .matchParentSize()
+            .then(if (useBlur) Modifier.haze(state = hazeState) else Modifier)
+        )
+
+        // Content overlay
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .background(Color.Transparent),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                val tfHazeModifier = if (useBlur) {
+                    Modifier.hazeChild(state = hazeState, shape = RoundedCornerShape(textfieldCornerRadius.dp), style = dev.chrisbanes.haze.HazeStyle(blurRadius = 25.dp, backgroundColor = Color.Transparent, tint = dev.chrisbanes.haze.HazeTint(Color.Black.copy(alpha = 0.2f))))
+                } else Modifier
+
+                val btnHazeModifier = if (useBlur) {
+                    Modifier.hazeChild(state = hazeState, shape = RoundedCornerShape(sendButtonCornerRadius.dp), style = dev.chrisbanes.haze.HazeStyle(blurRadius = 25.dp, backgroundColor = Color.Transparent, tint = dev.chrisbanes.haze.HazeTint(Color.Black.copy(alpha = 0.2f))))
+                } else Modifier
+                
+                Box(modifier = Modifier
+                    .weight(1f)
+                    .then(
+                        Modifier.heightIn(
+                            min = 56.dp,
+                            max = 200.dp
+                        )
+                    )
+                ) {
+                    // Blurred Background Layer
+                    Box(modifier = Modifier
+                        .matchParentSize()
+                        .then(tfHazeModifier)
+                        .background(if (useBlur) tfBgColor.copy(alpha = 0.5f) else tfBgColor, RoundedCornerShape(textfieldCornerRadius.dp))
+                    )
+                    
+                    // Content Layer (Sharp)
+                    TextField(
+                        value = stringResource(R.string.reply_hint),
+                        onValueChange = { },
+                        modifier = Modifier.fillMaxWidth(),
+                        textStyle = androidx.compose.ui.text.TextStyle(color = txtColor),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        ),
+                        maxLines = 4,
+                        enabled = false
+                    )
+                }
+                
+                Box(
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .size(56.dp)
+                ) {
+                    // Blurred Background Layer
+                    Box(modifier = Modifier
+                        .matchParentSize()
+                        .then(btnHazeModifier)
+                        .background(if (useBlur) MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f) else MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(sendButtonCornerRadius.dp))
+                    )
+                    
+                    // Content Layer (Sharp)
+                    IconButton(
+                        onClick = { },
+                        enabled = true,
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = sendColor
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -652,6 +652,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -680,4 +704,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -643,6 +643,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -671,4 +695,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -632,6 +632,33 @@
     <string name="enable_triggers">Habilitar eventos específicos</string>
     <string name="open_source_licenses">Licencias de código abierto</string>
     <string name="live_updates">Comportamiento de la notificación original</string>
+    <string name="enable_inline_reply_desc">Inicia la superposición de respuesta rápida al responder desde la isla.</string>
+    <string name="remove_original_notification_hidden_warning">Nota: Al estar activado, Hyper Bridge no puede responder o marcar mensajes como leídos. Las acciones Responder y Marcar como leído se ocultarán.</string>
+
+    <string name="color_mode">Modo de Color</string>
+    <string name="color_mode_select">Seleccionar Modo de Color</string>
+    <string name="color_mode_change_cd">Cambiar modo de color</string>
+    <string name="color_mode_default">Por Defecto</string>
+    <string name="color_mode_default_desc">Usar colores estándar</string>
+    <string name="color_mode_app">Colores de App</string>
+    <string name="color_mode_app_desc">Extraer colores del icono de la aplicación</string>
+    <string name="color_mode_material">Material You</string>
+    <string name="color_mode_material_desc">Adaptar al fondo de pantalla del sistema (Monet)</string>
+    <string name="color_mode_custom">Colores Personalizados</string>
+    <string name="color_mode_custom_desc">Elige tus propios colores manualmente</string>
+
+    <string name="reply_textfield_color">Color de Cuadro de Texto</string>
+    <string name="reply_textfield_color_desc">Fondo del cuadro de texto</string>
+    <string name="reply_text_color">Color del Texto</string>
+    <string name="reply_text_color_desc">Color del texto de respuesta</string>
+    <string name="reply_send_color">Color de Enviar</string>
+    <string name="reply_send_color_desc">Color del icono de enviar</string>
+
+    <string name="reply_appearance">Apariencia</string>
+    <string name="reply_blur_effect">Efecto Desenfocado</string>
+    <string name="reply_blur_effect_desc">Aplica desenfoque tipo cristal al fondo</string>
+    <string name="reply_textfield_radius">Borde del Cuadro de Texto</string>
+    <string name="reply_send_radius">Borde del Botón de Enviar</string>
     <string name="remove_original_notification">Eliminar notificación original</string>
     <string name="remove_original_notification_desc">Descartar automáticamente la notificación original cuando una Live Update está activa.</string>
     <string name="dismiss_with_original">Descartar con original</string>
@@ -642,20 +669,23 @@
     <string name="onboard_design_desc">Amplía las posibilidades con diferentes opciones de personalización</string>
     <string name="behavior_desc_glob_config">Determina el comportamiento de la isla.</string>
     <string name="widget_layout_snapshot">Vista previa del widget</string>
-
     <string name="changelog_0_5_2">
+        <b>¡Nueva Respuesta Rápida!</b>\n
+              • <b>Respuesta Rápida:</b> ¡Ahora puedes responder a los mensajes directamente desde la isla sin abrir la app!\n
+              • <b>Personalización:</b> Personaliza completamente el aspecto del nuevo editor de respuestas rápidas a nivel global o por aplicación.\n
+              • <b>Ajustes Globales:</b> Accede a la nueva sección de personalización de Respuestas directamente desde los Ajustes Globales -> Respuesta Rápida.\n
+        \n
         <b>Actualización de Rendimiento y Estabilidad</b>\n
               • <b>Creador de Temas:</b> Se resolvió un cierre inesperado al cargar conjuntos de iconos grandes.\n
-              • <b>Mejora en la Bienvenida:</b> Eliminado un error de "Aplicación no Responde" (ANR) en la primera pantalla.\n
+              • <b>Mejora en la Bienvenida:</b> Eliminado un error de \"Aplicación no Responde\" (ANR) en la primera pantalla.\n
               • <b>Selector de Widgets:</b> Prevenidos cierres y errores de falta de memoria (OOM) causados por vistas previas gigantes.\n
               • <b>Diseño Más Robusto:</b> Solucionados problemas de restricciones de diseño en Jetpack Compose al achicar menús.\n
               • <b>Copias de Seguridad:</b> Mejorado el análisis de JSON, evitando errores de OOM al restaurar archivos grandes.\n
               • <b>Inicio Rápido:</b> Reducción significativa de los bloqueos de la interfaz, acelerando el inicio de la app en dispositivos de gama media.\n
               • <b>Servicio en Segundo Plano:</b> Arquitectura de memoria del Notification Listener completamente rediseñada, reduciendo el consumo en segundo plano al 0% y mejorando la batería.\n
     </string>
-    <string name="title_0_5_2">Actualización de Rendimiento y Estabilidad</string>
-    <string name="changelog_0_5_1">
-        <b>Correcciones y Estabilidad</b>\n
+    <string name="title_0_5_2">Respuesta Rápida, Rendimiento y Estabilidad</string>
+    <string name="changelog_0_5_1">        <b>Correcciones y Estabilidad</b>\n
               Corrección de Duplicados en WhatsApp: Resuelto un problema que causaba que aparecieran notificaciones duplicadas de WhatsApp.\n
               Corrección de Parpadeos y Cierres: Solucionado un cierre inesperado causado al recibir múltiples notificaciones en un corto período. La aplicación ahora actualiza las notificaciones de manera segura, eliminando el parpadeo y mejorando la estabilidad.\n
               Intenciones Restauradas: Corregido un problema donde al hacer clic en una notificación destacada, la app te dirigía incorrectamente a la pantalla de solución de problemas en lugar de abrir la aplicación original.\n\n
@@ -664,12 +694,11 @@
               Diagnóstico de Notificaciones: Añadida una nueva pantalla de verificación durante la configuración inicial para comprobar si tu dispositivo Xiaomi es compatible con las Notificaciones Destacadas.\n
               Integración de Estado del Sistema: El estado de los permisos de Notificaciones Destacadas ahora se monitoriza continuamente y se muestra dentro de la pantalla de Estado del Sistema.\n
               Pantalla de Solución de Problemas: Añadida una pantalla dedicada que guía a los usuarios sobre cómo habilitar los permisos ocultos del sistema (o usar Shizuku).\n
-              Terminología Más Clara: Renombrada la sección de "Actualizaciones en Vivo" en el menú de ajustes a "Gestión de Notificaciones" para reflejar mejor su propósito.\n
-              Pulido de Interfaz en Ajustes: Restauradas las esquinas redondeadas faltantes en la opción "Isla Permanente" en la lista de Ajustes Globales.\n
+              Terminología Más Clara: Renombrada la sección de \"Actualizaciones en Vivo\" en el menú de ajustes a \"Gestión de Notificaciones\" para reflejar mejor su propósito.\n
+              Pulido de Interfaz en Ajustes: Restauradas las esquinas redondeadas faltantes en la opción \"Isla Permanente\" en la lista de Ajustes Globales.\n
               Traducciones al Español: Añadidas traducciones completas al español para todos los nuevos diálogos de solución de problemas, verificaciones del sistema y ajustes.
     </string>
     <string name="title_0_5_1">Correcciones y Mejoras</string>
-
     <string name="changelog_0_5_0"><b>Soporte para ROMs CN</b>\n
             • Habilita la nueva solución Sui &amp; Shizuku para disfrutar de Hyper Islands en tus dispositivos con ROMs HyperOS CN (China) sin soporte nativo.\n\n
         <b>Mejoras del Motor de Temas</b>\n
@@ -698,7 +727,6 @@
     <string name="notification_went_wrong">¡Si ves esto, algo salió mal! Haz clic aquí para ver cómo solucionarlo.</string>
     <string name="widget_went_wrong">Si estás viendo esto, algo salió mal! El sistema no puede mostrar el widget</string>
     <string name="troubleshoot_featured_notification">Solucionar</string>
-
     <string name="featured_notifications_check">Test Notificaciones Destacadas</string>
     <string name="featured_notifications_check_desc">Vamos a verificar si tu sistema está configurado correctamente para mostrar las islas de HyperBridge.</string>
     <string name="featured_notifications_supported">Soportado</string>
@@ -708,11 +736,15 @@
     <string name="featured_notifications_open_settings">Abrir Ajustes del Sistema</string>
     <string name="featured_notifications_banner_warning">Las notificaciones destacadas están deshabilitadas. Las islas no se mostrarán correctamente.</string>
     <string name="featured_notifications_troubleshoot_title">¿Por qué esto no es una isla?</string>
-    <string name="featured_notifications_troubleshoot_desc">Tu dispositivo Xiaomi interceptó la notificación pero no pudo mostrarla como una isla destacada porque el permiso está deshabilitado en los ajustes del sistema.\n\nPara solucionar esto:\n1. Toca "Abrir Ajustes del Sistema"\n2. Desplázate hacia abajo hasta "Notificaciones Destacadas" (o similar)\n3. Habilítalo para HyperBridge.</string>
+    <string name="featured_notifications_troubleshoot_desc">Tu dispositivo Xiaomi interceptó la notificación pero no pudo mostrarla como una isla destacada porque el permiso está deshabilitado en los ajustes del sistema.\n\nPara solucionar esto:\n1. Toca \"Abrir Ajustes del Sistema\"\n2. Desplázate hacia abajo hasta \"Notificaciones Destacadas\" (o similar)\n3. Habilítalo para HyperBridge.</string>
     <string name="featured_notifications_shizuku_alternative">Alternativa: Usar Shizuku</string>
     <string name="featured_notifications_shizuku_desc">Si tu sistema no muestra el ajuste o está restringido, puedes eludir la lista blanca de Xiaomi completamente configurando Shizuku. HyperBridge usará Shizuku para publicar las islas directamente.</string>
     <string name="system_config_info">Información de Configuración del Sistema</string>
     <string name="system_config_info_supported_label">Soportado: %1$s</string>
     <string name="system_config_info_permission_label">Permiso: %1$s</string>
     <string name="notification_management">Gestión de Notificaciones</string>
+    <string name="enable_inline_reply">Habilitar respuesta rápida</string>
+    <string name="inline_reply_title">Respuesta rápida</string>
+    <string name="customize_inline_reply">Personalizar el diseño de la respuesta</string>
+    <string name="reply_hint">Responder...</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -24,17 +24,17 @@
     <string name="incompatible_msg">HyperBridge s\'appuie sur des fonctionnalités spécifiques du système HyperOS. Le fabricant de votre appareil ne semble pas être Xiaomi/POCO/Redmi.</string>
     <string name="system_detected">✅ Système détecté</string>
     <string name="app_wont_work">⚠️ L\'appli peut ne pas fonctionner</string>
-    <string name="show_island">Afficher la bulle</string>
-    <string name="perm_post_desc">Nous avons besoin de la permission pour publier la notification \"Island\" sur votre écran.</string>
+    <string name="show_island">Affichage des notifications</string>
+    <string name="perm_post_desc">Nous avons besoin de la permission pour publier les notifications \"HyperIsland\" sur votre écran.</string>
     <string name="perm_granted">Permission accordée</string>
     <string name="allow_notifications">Autoriser les notifications</string>
     <string name="read_data">Lire les données</string>
     <string name="perm_listener_desc">Pour connecter vos applications, nous devons lire leurs notifications (Musique, Maps, Horloge).</string>
     <string name="open_settings">Ouvrir les paramètres</string>
     <string name="keep_alive">Garder actif</string>
-    <string name="optimization_desc">HyperOS tue les applications en arrière-plan. Activez le démarrage automatique et pas de restrictions pour garder l\'application active.</string>
-    <string name="enable_autostart">1. Activer le démarrage automatique</string>
-    <string name="set_battery_no_restrictions">2. Définir le mode de batterie sur \'Aucune restriction\'</string>
+    <string name="optimization_desc">HyperOS tue les applications en arrière-plan. Activez le démarrage automatique et sans restrictions pour garder l\'application active.</string>
+    <string name="enable_autostart">Activer le démarrage automatique en arrière-plan</string>
+    <string name="set_battery_no_restrictions">Définir le mode de batterie sur \'Pas de restriction\'</string>
     <string name="tab_active">Actif</string>
     <string name="tab_library">Bibliothèque</string>
     <string name="title_active_bridges">Applications actives</string>
@@ -53,9 +53,9 @@
     <string name="system_setup_subtitle">Corriger les permissions &amp; batterie</string>
     <!-- Permanent Island -->
     <string name="permanent_island_title">Notification permanente</string>
-    <string name="permanent_island_desc">Gardez Dynamic Island visible en permanence à l\'écran lorsqu\'il n\'y a pas de notification active.</string>
-    <string name="permanent_island_screen_desc">Lorsque cette option est activée, une île dynamique vide sera affichée de façon permanente sur votre écran. Il se masquera automatiquement lorsque des notifications réelles arriveront et réapparaîtra lorsque toutes les notifications seront effacées. Elles ne seront pas visibles dans votre zone de notification.</string>
-    <string name="permanent_island_width">Largeur de l\'île</string>
+    <string name="permanent_island_desc">Gardez la zone de notification visible en permanence à l\'écran lorsqu\'il n\'y a pas de notification active.</string>
+    <string name="permanent_island_screen_desc">Lorsque cette option est activée, une zone de notification vide sera affichée de façon permanente sur votre écran. Elle se masquera automatiquement lorsque des notifications réelles arriveront et réapparaîtra lorsque toutes les notifications seront effacées. Elle ne sera pas visibles dans votre zone de notification.</string>
+    <string name="permanent_island_width">Largeur de la zone</string>
     <string name="group_about">A propos</string>
     <string name="developer">Développeur</string>
     <string name="developer_subtitle">Visiter d4viddf.com</string>
@@ -85,7 +85,7 @@
     <string name="cat_other">Autre</string>
     <string name="select_active_notifs">Sélectionner les notifications actives</string>
     <string name="type_standard">Messages &amp; Général</string>
-    <string name="type_progress">Téléchargements &amp; Progression</string>
+    <string name="type_progress">Avancements &amp; Tâches</string>
     <string name="type_download">Téléchargements</string>
     <string name="type_media">Musique &amp; Média</string>
     <string name="type_nav">Cartes &amp; GPS</string>
@@ -174,7 +174,7 @@
         • &lt;b&gt;Localisation :&lt;/b&gt; Ajout de la langue espagnole
     </string>
     <string name="priority_edu_title">Nouveau : Contrôler la bulle de notification</string>
-    <string name="priority_edu_desc">HyperBridge peut maintenant gérer le comportement de plusieurs notifications lorsque la limite de 9 bulles est atteinte.\n\n&lt;b&gt;Par défaut : Les plus récentes&lt;/b&gt;\nLes nouvelles notifications remplacent automatiquement les plus anciennes.</string>
+    <string name="priority_edu_desc">Choisissez comment l\'île devrait se comporter lorsque plusieurs notifications sont actives en même temps.</string>
     <string name="keep_default">Conserver la valeur par défaut</string>
     <string name="configure_now">Configurer maintenant</string>
     <string name="badge_new">NOUVEAU</string>
@@ -285,7 +285,7 @@
         • Écran de vérification de compatibilité amélioré avec des informations détaillées sur l\'appareil
     </string>
     <string name="privacy_title">100% hors ligne &amp; sécurisé</string>
-    <string name="privacy_desc">Hyper Bridge traite tout directement via le processeur de votre téléphone.\n\nIl ne nécessite PAS un accès à Internet, ce qui signifie que vos notifications et vos données personnelles ne quittent jamais votre appareil.</string>
+    <string name="privacy_desc">Hyper Bridge traite tout directement via le processeur de votre téléphone.\n\nIl ne nécessite PAS d\'accès à Internet, ce qui signifie que vos notifications et vos données personnelles ne quittent jamais votre appareil.</string>
     <string name="language">Langue</string>
     <string name="language_desc">Changer la langue de l\'application</string>
     <string name="system_default">Par défaut (Système)</string>
@@ -538,30 +538,30 @@
         <item quantity="other">%1$d actions personnalisées</item>
     </plurals>
     <string name="title_0_4_0">La version de la personnalisation</string>
-    <string name="changelog_0_4_0">        &lt;b&gt;Système de thèmes :&lt;/b&gt;\n
+    <string name="changelog_0_4_0">       <b>Système de thèmes 🎨</b>\n
         La plus grande mise à jour ! Vous pouvez maintenant personnaliser pleinement l\'expérience visuelle des bulles de notification. \n
-        • &lt;b&gt;Créateur de Thèmes :&lt;/b&gt; Concevez des thèmes directement sur votre téléphone avec un aperçu en temps réel.\n
-        • &lt;b&gt;Paramétrage plus fin:&lt;/b&gt; Choisissez exactement comment les icônes sont affichées, personnalisez les couleurs et les formes des notifications, et configurer les remplacements des applications individuelles.\n
-        • &lt;b&gt;Couleurs intelligentes:&lt;/b&gt; Extraction automatique des couleurs des icônes d\'application.\n
-        • &lt;b&gt;Personnalisation par action (Bêta):&lt;/b&gt; &lt;/b&gt; Ajustement de l\'apparence de certaines notifications d\'actions spécifiques.\n
-        • &lt;b&gt;Partage :&lt;/b&gt; Exportez et importez des thèmes au format &lt;i&gt;.hbr&lt;/i&gt; .\n\n
+        • <b>Créateur de Thèmes :</b> Concevez des thèmes directement sur votre téléphone avec un aperçu en temps réel.\n
+        • <b>Paramétrage plus fin:</b>; Choisissez exactement comment les icônes sont affichées, personnalisez les couleurs et les formes des notifications, et configurer les remplacements des applications individuelles.\n
+        • <b>Couleurs intelligentes:</b>; Extraction automatique des couleurs des icônes d\'application.\n
+        •<b>Personnalisation par action (Bêta):</b>; Ajustement de l\'apparence de certaines notifications d\'actions spécifiques.\n
+        • <b>Partage :</b> Exportez et importez des thèmes au format <i>hbr</i> .\n\n
 
-        &lt;b&gt;Support des widget 🧩&lt;/b&gt;\n
-        Verrouillez les widgets standard d\'Android pour un accès rapide — même sur votre &lt;b&gt;écran verrouillé&lt;/b&gt;!\n
-        • Choisissez entre les modes  &lt;b&gt;interractifs&lt;/b&gt; pour la vitesse ou &lt;b&gt;instantané&lt;/b&gt; pour l\'efficacité de la batterie.\n\n
+        <b>Support des widget 🧩</b>\n
+        Verrouillez les widgets standard d\'Android pour un accès rapide — même sur votre <b>écran verrouillé</b>!\n
+        • Choisissez entre les modes <b>interractifs</b> pour la vitesse ou <b>instantané</b> pour l\'efficacité de la batterie.\n\n
 
-        &lt;b&gt;Moteur de notification 2.0⚡&lt;/b&gt;\n
+        <b>Moteur de notification 2.0⚡</b>\n
         Réécriture complète du moteur pour une meilleure stabilité:\n
-        • &lt;b&gt;Analyse intelligente : &lt;/b&gt; Résolutions de problèmes où les notifications affichaient les noms des paquets (par ex. : com.whatsapp) au lieu du contenu du message.\n
-        • &lt;b&gt;Anti-scintillement :&lt;/b&gt; La vérification de contenu empêche les notifications redondantes et les saccades.\n
-        • &lt;b&gt;Correction des fantômes :&lt;/b&gt; Résolution d\'un problème où les notifications persistaient après leur suppression.\n\n
+        • <b>Analyse intelligente : </b> Résolutions de problèmes où les notifications affichaient les noms des paquets (par ex. : com.whatsapp) au lieu du contenu du message.\n
+        • <b>Anti-scintillement :</b> La vérification de contenu empêche les notifications redondantes et les saccades.\n
+        • <b>Correction des fantômes :</b> Résolution d\'un problème où les notifications persistaient après leur suppression.\n\n
 
-        &lt;b&gt;Rafraîchissement visuel ✨&lt;/b&gt;\n
+        <b>Rafraîchissement visuel ✨</b>\n
         • Onglet \"Design\" redessiné pour plus de fluidité avec des blocs dynamiques.\n
         • Nouveaux boutons de textes pour des actions de notification plus claires.\n
         • Ajout du support pour l\'indonésien 🇮🇩 et le turque 🇹🇷.\n\n
 
-        &lt;i&gt;Note : Cette version comprend des changements architecturaux importants. Veuillez signaler tout bug sur GitHub !&lt;/i&gt;
+        <i>Note : Cette version comprend des changements architecturaux importants. Veuillez signaler tout bug sur GitHub !</i>
     </string>
     <string name="title_0_4_2">Mise à jour de corrections de bugs</string>
     <string name="changelog_0_4_2">        •&lt;b&gt;Correction d\'un crash :&lt;/b&gt; Résolution d\'un problème critique qui faisait planter l\'application lors de l\'ouverture du menu des paramètres en chinois traditionnel.\n
@@ -599,7 +599,7 @@
     <string name="island_behavior_title">Comportement de la bulle</string>
     <string name="island_behavior_desc"><![CDATA[Délai d’expiration, doublons et visibilité]]></string>
     <string name="engine">Moteur</string>
-    <string name="engine_desc">Notifications natives vs Xiaomi</string>
+    <string name="engine_desc">Notifications natives ou Xiaomi</string>
     <string name="dnd_mode_title">Ne pas déranger</string>
     <string name="dnd_mode_desc">Gérer la visibilité de l\'île pendant le NPD</string>
     <string name="dnd_manual_toggle">Suspendre les bulles de notifications</string>
@@ -609,22 +609,22 @@
     <string name="behaviour_triggers"><![CDATA[Comportement et Déclencheurs]]></string>
     <string name="engine_timeouts_triggers"><![CDATA[Moteur, délai d’expiration et déclencheurs]]></string>
     <string name="global_behavior">Comportement global</string>
-    <string name="auto_hide_island">Cacher automatiquement la bulle de notification</string>
-    <string name="hides_after_a_set_time">Masquer après une heure définie</string>
+    <string name="auto_hide_island">Cacher automatiquement la notification</string>
+    <string name="hides_after_a_set_time">Masquer après un temps défini</string>
     <string name="behavior_hide_desc">Visible jusqu\'au masquage manuel</string>
     <string name="behavior_desc_hide_long">Détermine combien de temps la bulle de notification reste à l\'écran avant de disparaître automatiquement.</string>
     <string name="managed_by_theme_desc">Comportement géré par le thème actif.</string>
     <string name="use_global_default_engine">Utiliser la valeur par défaut du moteur de notification</string>
     <string name="active_triggers">Déclencheurs actifs</string>
-    <string name="active_triggers_global_desc">Sélectionnez quels événements globaux déclenchent les notifications</string>
+    <string name="active_triggers_global_desc">Sélectionnez quels évènements déclenchent les notifications</string>
     <string name="type_standard_desc">Messages standards, emails et alertes</string>
-    <string name="type_progress_desc">Téléchargements, envois et tâches en cours</string>
+    <string name="type_progress_desc">Tâches, rendu et opérations en cours</string>
     <string name="type_download_desc">Téléchargements, envois et transferts de fichiers</string>
     <string name="type_media_desc">Contrôles de lecture de musique et de vidéo</string>
     <string name="type_nav_desc">Instructions de navigation et temps estimé d\'arrivée</string>
     <string name="type_call_desc">Appels entrants et en cours</string>
     <string name="type_timer_desc">Minuteurs et chronomètres actifs</string>
-    <string name="select_triggered_events">Sélectionner les événements déclenchés</string>
+    <string name="select_triggered_events">Sélectionner les évènements déclenchés</string>
     <string name="override_global_triggers">Outrepasser les déclencheurs globaux</string>
     <string name="override_global_trigger_desc">Définir des notifications personnalisées autorisées pour cette application</string>
     <string name="trigger_override">Remplacement du déclencheur</string>
@@ -634,14 +634,38 @@
     <string name="live_updates">Mises à jour en temps réel</string>
     <string name="remove_original_notification">Supprimer la notification originale</string>
     <string name="remove_original_notification_desc">Ignorer automatiquement la notification source quand une mise à jour en direct est active.</string>
-    <string name="dismiss_with_original">Dismiss with original</string>
-    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
+    <string name="dismiss_with_original">Rejeter avec l\'origine</string>
+    <string name="dismiss_with_original_desc">La bulle de notification disparaîtra lorsque vous effacerez la notification d\'origine.</string>
     <string name="onboarding_can_be_changed">Vous pourrez modifier ces options plus tard dans Paramètres et Configurateur de thèmes.</string>
-    <string name="onboarding_widget_desc">Ajoutez des widgets standard Android à votre bulle de notification pour un accès rapide.</string>
-    <string name="onboard_theme_desc">Personnalisez entièrement les couleurs, les formes et les icônes de votre bulle de notification.</string>
+    <string name="onboarding_widget_desc">Ajoutez des widgets Android à votre bulle de notification pour un accès rapide.</string>
+    <string name="onboard_theme_desc">Personnalisez entièrement les couleurs, les formes et les icônes de vos bulles de notification.</string>
     <string name="onboard_design_desc">Augmentez les possibilités avec différentes options de personnalisation</string>
     <string name="behavior_desc_glob_config">Détermine le comportement de la bulle de notification.</string>
     <string name="widget_layout_snapshot">Aperçu du widget</string>
+    <string name="changelog_0_5_2">        <b>Correction de crash du Play Store &amp; Stabilité</b>\n
+              ? <b>Créateur de thème :</b> Correction d\'un plantage lors de l\'analyse d\'un grand nombre d\'actifs personnalisés.\n
+              ? <b>Performances :</b> Résolution d\'un problème d’application qui ne répond plus (ANR) sur l’écran initial de bienvenue.\n
+              ? <b>Widget Picker:</b> Elimination de plantages et d\'erreurs Out-Of-Memory (OOM) causés par une prévisualisation de Widget extremement large.\n
+              ? <b>Dispositions de l\'interface utilisateur :</b> Correction des exceptions sur les contraintes de mise en page de composition de Jetpack qui plantaient l\'application lors du redimensionnement de certains menus.\n
+              ? <b>Sauvegardes :</b> Erreurs OOM résolues lors de l\'importation de gros fichiers de sauvegarde en optimisant l\'analyse JSON.\n
+              ? <b>Démarrage chaud :</b> Amélioration significative des vitesses de lancement des applications et élimination du blocage des piles d\'interface utilisateur sur les appareils de milieu de gamme.\n
+              ? <b>Service d\'arrière-plan :</b> Révision complète de l\'architecture du traitement d\'écoute, chute de la charge en arrière-plan à 0 % et amélioration de la durée de vie de la batterie.\n
+    </string>
+    <string name="title_0_5_2">Mise à jour de la stabilité &amp; des performances</string>
+    <string name="changelog_0_5_1">        <b>Corrections &amp; stabilité</b>\n
+              Correction des doublons WhatsApp : résolution d\'un problème qui entraînait l\'affichage de notifications WhatsApp en double.\n
+              Correction du scintillement des notifications &amp; des plantages : correction d\'un plantage provoqué par la réception de plusieurs notifications en peu de temps. L\'application met désormais à jour les notifications normalement et en toute sécurité, ce qui élimine le scintillement des notifications et améliore la stabilité.\n
+              Restauration des intentions de notification : correction d\'un problème où cliquer sur une notification mise en avant redirigeait à tort vers l\'écran de dépannage au lieu de l\'application d\'origine.\n\n
+        <b>Fonctionnalités &amp; améliorations</b>\n
+              Suppression de l\'îlot lors de la fermeture : ajout d\'une nouvelle option permettant de supprimer automatiquement l\'îlot si la notification système d\'origine est fermée.\n
+              Diagnostic des notifications en vedette : ajout d\'un nouvel écran de vérification lors de la configuration initiale pour vérifier si votre appareil Xiaomi prend en charge les notifications en vedette et si les autorisations requises sont activées.\n
+              Intégration à l\'état de la configuration : l\'état des autorisations pour les notifications en vedette est désormais surveillé en continu et affiché dans l\'écran d\'état de la configuration.\n
+              Écran de dépannage : ajout d\'un écran de dépannage dédié qui guide les utilisateurs sur la manière d\'activer les autorisations système cachées nécessaires (ou d\'utiliser Shizuku) pour que les bulles de notifications fonctionnent sur les ROM Xiaomi strictes.\n
+              Terminologie plus claire : la section « Mises à jour en direct » du menu des paramètres a été renommée « Gestion des notifications » afin de mieux refléter\n
+            Polissage de l\'Interface utilisateur : rétablissement des coins arrondis qui manquaient dans l\'option « bulles permanentes » de la liste des paramètres généraux.\n
+              Traductions en espagnol : ajout de traductions complètes en espagnol pour toutes les nouvelles boîtes de dialogue de dépannage, les contrôles d\'intégrité de la configuration et les paramètres de gestion des notifications.
+    </string>
+    <string name="title_0_5_1">Corrections &amp; Affinements</string>
     <string name="changelog_0_5_0">        <b>Support ROM CN</b>\n
             • Utilisez Sui &amp; Shizuku pour profiter des notifications Hyper Islands sur vos appareils exécutant des ROM HyperOS CN (chinois) sans prise en charge native.\n\n
         <b>Améliorations du moteur de thème</b>\n
@@ -670,4 +694,21 @@
     <string name="title_0_5_0">La mise à jour \"Live Update\"</string>
     <string name="notification_went_wrong">Si vous voyez cela, quelque chose s\'est mal passé !</string>
     <string name="widget_went_wrong">Si vous voyez ceci, quelque chose s\'est mal passé ! Le système n\'a pas pu afficher le widget</string>
+    <string name="troubleshoot_featured_notification">Résolution des problèmes</string>
+    <string name="featured_notifications_check">Vérification des notifications recommandées</string>
+    <string name="featured_notifications_check_desc">Vérifions si votre système est correctement configuré pour afficher les notifications HyperBridge.</string>
+    <string name="featured_notifications_supported">Pris en charge</string>
+    <string name="featured_notifications_not_supported">Non pris en charge</string>
+    <string name="featured_notifications_enabled">Activé</string>
+    <string name="featured_notifications_disabled">Désactivé</string>
+    <string name="featured_notifications_open_settings">Ouvrir les paramètres système</string>
+    <string name="featured_notifications_banner_warning">Les notifications recommandées sont désactivées. Les bulles de notifications ne s\'afficheront pas correctement.</string>
+    <string name="featured_notifications_troubleshoot_title">Pourquoi ce n\'est pas une bulle de notification ?</string>
+    <string name="featured_notifications_troubleshoot_desc">Votre appareil Xiaomi a intercepté la notification, mais n\'a pas réussi à l\'afficher en tant que notification recommandée car la permission est désactivée dans vos paramètres système.\n\nPour résoudre ceci:\n1. Appuyez sur \"Ouvrir les paramètres du système\"\n2. Faites défiler vers le bas jusqu\'à \"Notifications recommandées\" (ou similaires)\n3. Activez-le pour HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative : remplacement par Shizuku</string>
+    <string name="featured_notifications_shizuku_desc">Si votre système n\'affiche pas le paramètre ou s\'il est restreint, vous pouvez contourner entièrement la liste blanche de Xiaomi en configurant Shizuku. HyperBridge utilisera Shizuku pour afficher directement les bulles de notifications.</string>
+    <string name="system_config_info">Infos sur la configuration système</string>
+    <string name="system_config_info_supported_label">Pris en charge : %1$s</string>
+    <string name="system_config_info_permission_label">Permissions %1$s</string>
+    <string name="notification_management">Gestion des notifications</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -641,6 +641,30 @@ Továbbfejlesztett felismerési logika a VoIP- és tárcsázóalkalmazások szé
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -669,4 +693,21 @@ Továbbfejlesztett felismerési logika a VoIP- és tárcsázóalkalmazások szé
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -632,6 +632,30 @@ Penulisan ulang total logika inti untuk stabilitas yang lebih baik.\n
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -660,4 +684,21 @@ Penulisan ulang total logika inti untuk stabilitas yang lebih baik.\n
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -642,6 +642,30 @@
     <string name="onboard_design_desc">Espandi le possibilità con diverse opzioni di personalizzazione</string>
     <string name="behavior_desc_glob_config">Determina come si comporta l\'isola.</string>
     <string name="widget_layout_snapshot">Anteprima widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -670,4 +694,21 @@
     <string name="title_0_5_0">Il Live Update</string>
     <string name="notification_went_wrong">Se stai vedendo questo, qualcosa è andato storto!</string>
     <string name="widget_went_wrong">Se stai vedendo questo, qualcosa è andato storto! Il sistema non ha potuto mostrare il widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -632,6 +632,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -660,4 +684,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -652,6 +652,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -680,4 +704,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -650,6 +650,30 @@ Por favor, verifique manualmente para garantir que o serviço funcione corretame
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -678,4 +702,21 @@ Por favor, verifique manualmente para garantir que o serviço funcione corretame
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permissão: %1$s</string>
+    <string name="notification_management">Gestão de notificações</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -653,6 +653,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -681,4 +705,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-sk-rSK/strings.xml
+++ b/app/src/main/res/values-sk-rSK/strings.xml
@@ -652,6 +652,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -680,4 +704,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -642,6 +642,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -670,4 +694,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -652,6 +652,30 @@
     <string name="onboard_design_desc">Expand the possibilities with different customization options</string>
     <string name="behavior_desc_glob_config">Determines how the island behaves.</string>
     <string name="widget_layout_snapshot">Preview of the widget</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1">        <b>Fixes &amp; Stability</b>\n
+              WhatsApp Duplicates Fixed: Resolved an issue that caused duplicate WhatsApp notifications to appear.\n
+              Notification Flicker &amp; Crashes Fixed: Fixed a crash caused by receiving multiple notifications in a short timeframe. The app now safely updates notifications normally, eliminating the notification flicker and improving stability.\n
+              Notification Intents Restored: Fixed an issue where clicking a featured notification would incorrectly route to the troubleshooting screen instead of the original app.\n\n
+        <b>Features &amp; Polish</b>\n
+              Remove Island on Dismiss: Added a new option to automatically remove the island if the original system notification is dismissed.\n
+              Featured Notifications Diagnostics: Added a new check screen during Onboarding to verify if your Xiaomi device supports Featured Notifications and if the required permissions are enabled.\n
+              Setup Health Integration: The Featured Notifications permission status is now continuously monitored and displayed inside the Setup Health screen.\n
+              Troubleshooting Screen: Added a dedicated Troubleshooting Screen that guides users on how to enable the necessary hidden system permissions (or use Shizuku) to get islands working on strict Xiaomi ROMs.\n
+              Clearer Terminology: Renamed the \"Live Updates\" section in the settings menu to \"Notification Management\" to better reflect its purpose.\n
+              Settings UI Polish: Restored the missing rounded corners on the \"Permanent Island\" option in the Global Settings list.\n
+              Spanish Translations: Added full Spanish translations for all the new troubleshooting dialogues, setup health checks, and notification management settings.
+    </string>
+    <string name="title_0_5_1">Fixes &amp; Refinements</string>
     <string name="changelog_0_5_0">        <b>CN ROM Support</b>\n
             • Enable the new Sui &amp; Shizuku workaround to enjoy the Hyper Islands in your devices running HyperOS CN (Chinese) ROMs without native support.\n\n
         <b>Theme Engine Improvements</b>\n
@@ -680,4 +704,21 @@
     <string name="title_0_5_0">The Live Update</string>
     <string name="notification_went_wrong">If you are seeing this, something went wrong!</string>
     <string name="widget_went_wrong">If you are seeing this, something went wrong! The system couldn\'t show the widget</string>
+    <string name="troubleshoot_featured_notification">Troubleshoot</string>
+    <string name="featured_notifications_check">Featured Notifications Check</string>
+    <string name="featured_notifications_check_desc">Let\'s verify if your system is configured correctly to display HyperBridge islands.</string>
+    <string name="featured_notifications_supported">Supported</string>
+    <string name="featured_notifications_not_supported">Not Supported</string>
+    <string name="featured_notifications_enabled">Enabled</string>
+    <string name="featured_notifications_disabled">Disabled</string>
+    <string name="featured_notifications_open_settings">Open System Settings</string>
+    <string name="featured_notifications_banner_warning">Featured notifications are disabled. Islands will not show correctly.</string>
+    <string name="featured_notifications_troubleshoot_title">Why is this not an island?</string>
+    <string name="featured_notifications_troubleshoot_desc">Your Xiaomi device intercepted the notification but failed to display it as a featured island because the permission is disabled in your system settings.\n\nTo fix this:\n1. Tap \"Open System Settings\"\n2. Scroll down to \"Featured Notifications\" (or similar)\n3. Enable it for HyperBridge.</string>
+    <string name="featured_notifications_shizuku_alternative">Alternative: Shizuku Override</string>
+    <string name="featured_notifications_shizuku_desc">If your system doesn\'t show the setting or it\'s restricted, you can bypass the Xiaomi whitelist entirely by setting up Shizuku. HyperBridge will use Shizuku to post islands directly.</string>
+    <string name="system_config_info">System Configuration Info</string>
+    <string name="system_config_info_supported_label">Supported: %1$s</string>
+    <string name="system_config_info_permission_label">Permission: %1$s</string>
+    <string name="notification_management">Notification Management</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -629,14 +629,37 @@
     <string name="live_updates">即時更新</string>
     <string name="remove_original_notification">移除預設通知</string>
     <string name="remove_original_notification_desc">當即時更新處於啟用狀態時，自動關閉通知來源。</string>
-    <string name="dismiss_with_original">Dismiss with original</string>
-    <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
+    <string name="dismiss_with_original">不使用預設</string>
+    <string name="dismiss_with_original_desc">超級島通知會在您刪除通知欄通知後消失。</string>
     <string name="onboarding_can_be_changed">您稍後可以在「設定」和「主題配置器」中變更這些選項。</string>
     <string name="onboarding_widget_desc">在您的超級島上添加Android 小工具，以便快速存取。</string>
     <string name="onboard_theme_desc">完全自訂超級島的顏色、形狀和圖示。</string>
     <string name="onboard_design_desc">利用不同的自訂選項拓展可能性</string>
     <string name="behavior_desc_glob_config">決定超級島的呈現方式。</string>
     <string name="widget_layout_snapshot">預覽小工具</string>
+    <string name="changelog_0_5_2">        <b>Play Store Crash Fixes &amp; Stability</b>\n
+              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+    </string>
+    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="changelog_0_5_1"><b>修復 &amp; 穩定</b>\n
+              WhatsApp 重複通知修復：解決了 WhatsApp 通知重複出現的問題。 \n
+              通知閃爍 &amp; 崩潰修復：修復了短時間內收到多個通知導致的崩潰問題。應用程式現在可以安全地正常更新通知，消除了通知閃爍並提高了穩定性。 \n
+              通知 Intent 恢復：修正了點擊精選通知時會錯誤地跳到故障排除畫面而不是原始應用程式的問題。 \n\n
+              <b>功能 &amp; 最佳化</b>\n
+              關閉通知時移除超級島通知：新增選項，當系統通知關閉時，超級島通知將自動移除。 \n
+              精選通知診斷：在引導過程中新增檢查介面，用於驗證您的小米設備是否支援精選通知以及是否已啟用所需權限。 \n
+              設定健康整合：精選通知的權限狀態現在會持續監控並顯示在設定健康介面中。 \n
+              故障排除介面：新增專門的故障排除介面，引導使用者啟用必要的隱藏系統權限（或使用Shizuku），以使超級島通知在嚴格的小米 ROM 上正常運作。 \n
+              更清晰的術語：將設定選單中的“即時更新”部分重新命名為“通知管理”，以更好地體現其用途。 \n
+              設定介面最​​佳化：恢復了預設設定清單中「永久通知島」選項的圓角效果。 \n
+              西班牙文翻譯：為所有新增的故障排除對話方塊、設定健康檢查和通知管理設定新增了完整的西班牙文翻譯    </string>
+    <string name="title_0_5_1">修復 &amp; 改進</string>
     <string name="changelog_0_5_0">        <b> 中國版ROM 支援 </b>\n
         • 啟用新的 Sui &amp; Shizuku 變通方案，即可在執行 HyperOS 中國版ROM 且不支援原生功能的裝置上體驗小米超級島。 \n\n
         <b>主題引擎改善</b>\n
@@ -664,4 +687,21 @@
     <string name="title_0_5_0">即時更新</string>
     <string name="notification_went_wrong">如果您看到此訊息，說明出現錯誤！</string>
     <string name="widget_went_wrong">如果您看到此訊息，表示出錯了！系統無法顯示該小工具</string>
+    <string name="troubleshoot_featured_notification">故障排除</string>
+    <string name="featured_notifications_check">精選通知檢查</string>
+    <string name="featured_notifications_check_desc">讓我們驗證一下您的系統是否已正確配置以顯示 HyperBridge 超級島。</string>
+    <string name="featured_notifications_supported">支援</string>
+    <string name="featured_notifications_not_supported">不支援</string>
+    <string name="featured_notifications_enabled">啟用</string>
+    <string name="featured_notifications_disabled">已停用</string>
+    <string name="featured_notifications_open_settings">開啟系統設定</string>
+    <string name="featured_notifications_banner_warning">精選通知已停用。超級島將無法正確顯示。</string>
+    <string name="featured_notifications_troubleshoot_title">為什麼沒有超級島？</string>
+    <string name="featured_notifications_troubleshoot_desc">您的小米設備攔截了通知，但由於系統設定中權限已停用，因此無法將其顯示為精選通知。 \n\n要解決此問題：\n1. 點選「開啟系統設定」\n2. 向下捲動至「精選通知」（或類似選項）\n3. 為 HyperBridge 啟用此權限。</string>
+    <string name="featured_notifications_shizuku_alternative">替代方案：Shizuku 方法</string>
+    <string name="featured_notifications_shizuku_desc">如果您的系統未顯示此設定或該設定受到限制，您可以透過設定 Shizuku 來完全繞過小米白名單。 HyperBridge 將使用 Shizuku 直接發布超級島通知。</string>
+    <string name="system_config_info">系統配置資訊</string>
+    <string name="system_config_info_supported_label">支持：%1$s</string>
+    <string name="system_config_info_permission_label">權限：%1$s</string>
+    <string name="notification_management">通知管理</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -748,6 +748,35 @@
     <string name="remove_original_notification_desc">Automatically dismiss the source notification when a Live Update is active.</string>
     <string name="dismiss_with_original">Dismiss with original</string>
     <string name="dismiss_with_original_desc">Island will disappear when you clear the original notification.</string>
+    <string name="enable_inline_reply">Enable inline reply</string>
+    <string name="enable_inline_reply_desc">Launch the custom inline reply overlay when replying from the island.</string>
+    <string name="remove_original_notification_hidden_warning">Note: When enabled, Hyper Bridge cannot respond or mark messages as read. Reply and Mark as Read actions will be hidden.</string>
+    
+    <string name="color_mode">Color Mode</string>
+    <string name="color_mode_select">Select Color Mode</string>
+    <string name="color_mode_change_cd">Change color mode</string>
+    <string name="color_mode_default">Default</string>
+    <string name="color_mode_default_desc">Use default standard colors</string>
+    <string name="color_mode_app">App Colors</string>
+    <string name="color_mode_app_desc">Extract colors from the app icon</string>
+    <string name="color_mode_material">Material You</string>
+    <string name="color_mode_material_desc">Match the system wallpaper (Monet)</string>
+    <string name="color_mode_custom">Custom Colors</string>
+    <string name="color_mode_custom_desc">Manually choose your own colors</string>
+    
+    <string name="reply_textfield_color">Textfield Color</string>
+    <string name="reply_textfield_color_desc">Inner text box background</string>
+    <string name="reply_text_color">Text Color</string>
+    <string name="reply_text_color_desc">Reply text color</string>
+    <string name="reply_send_color">Send Button Color</string>
+    <string name="reply_send_color_desc">Send icon color</string>
+    
+    <string name="reply_appearance">Appearance</string>
+    <string name="reply_blur_effect">Blur Effect</string>
+    <string name="reply_blur_effect_desc">Apply glassmorphism to textfield</string>
+    <string name="reply_textfield_radius">Textfield Corner Radius</string>
+    <string name="reply_send_radius">Send Button Corner Radius</string>
+    
     <string name="onboarding_can_be_changed">You can change these options later in Settings and Theme Configurator.</string>
     <string name="onboarding_widget_desc">Add standard Android widgets to your island for quick access.</string>
     <string name="onboard_theme_desc">Fully customize colors, shapes and icons of your island.</string>
@@ -756,16 +785,21 @@
     <string name="widget_layout_snapshot">Preview of the widget</string>
 
     <string name="changelog_0_5_2">
+        <b>New Inline Reply Feature!</b>\n
+              • <b>Inline Reply:</b> You can now reply to messages directly from the island without opening the app!\n
+              • <b>Customization:</b> Fully customize the look of the new inline reply editor globally or per-app.\n
+              • <b>Global Settings:</b> Access the new Reply customization section directly from the Global Settings -> Inline reply.\n
+        \n
         <b>Play Store Crash Fixes &amp; Stability</b>\n
-              ? <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
-              ? <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
-              ? <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
-              ? <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
-              ? <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
-              ? <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
-              ? <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
+              • <b>Theme Creator:</b> Fixed a crash when parsing large sets of custom assets.\n
+              • <b>Performance:</b> Resolved an ANR (Application Not Responding) issue on the initial Welcome Screen.\n
+              • <b>Widget Picker:</b> Eliminated crashes and Out-Of-Memory (OOM) errors caused by extremely large widget previews.\n
+              • <b>UI Layouts:</b> Fixed Jetpack Compose layout constraint exceptions that crashed the app when resizing certain menus.\n
+              • <b>Backups:</b> Resolved OOM errors when importing large backup files by optimizing JSON parsing.\n
+              • <b>Warm Starts:</b> Significantly improved app launch speeds and eliminated UI thread blocking on mid-range devices.\n
+              • <b>Background Service:</b> Completely overhauled the Notification Listener memory architecture, dropping background overhead to 0% and improving battery life.\n
     </string>
-    <string name="title_0_5_2">Performance &amp; Stability Update</string>
+    <string name="title_0_5_2">Inline Reply, Performance &amp; Stability</string>
 
     <string name="changelog_0_5_1">
         <b>Fixes &amp; Stability</b>\n
@@ -830,5 +864,8 @@
     <string name="system_config_info_supported_label">Supported: %1$s</string>
     <string name="system_config_info_permission_label">Permission: %1$s</string>
     <string name="notification_management">Notification Management</string>
+    <string name="inline_reply_title">Inline Reply</string>
+    <string name="customize_inline_reply">Customize inline reply overlay</string>
+    <string name="reply_hint">Reply...</string>
 </resources>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ api = "13.1.5"
 datastorePreferences = "1.2.1"
 gson = "2.14.0"
 hyperislandKit = "0.4.4"
+haze = "1.1.1"
 kotlin = "2.3.21"
 kotlinxSerializationJson = "1.11.0"
 ksp = "2.3.2"
@@ -29,6 +30,8 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 api = { module = "dev.rikka.shizuku:api", version.ref = "api" }
+haze = { group = "dev.chrisbanes.haze", name = "haze", version.ref = "haze" }
+haze-materials = { group = "dev.chrisbanes.haze", name = "haze-materials", version.ref = "haze" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hyperisland-kit = { module = "io.github.d4viddf:hyperisland_kit", version.ref = "hyperislandKit" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
- **Inline Reply System**:
    - Introduced `InlineReplyService` to display a Compose-based system overlay for direct message replies using `SYSTEM_ALERT_WINDOW`.
    - Added `InlineReplyReceiver` to handle notification intents and launch the reply service from the background.
    - Updated `BaseTranslator` to intercept `RemoteInput` actions and route them through the custom overlay when enabled.
- **Customization & Themes**:
    - Added `ReplyStyleSheetContent` and `GlobalReplyCustomizationScreen` to allow fine-grained control over reply overlay colors, shapes, and transparency.
    - Integrated "Inline Reply" settings into `ThemeCreatorScreen` and `AppThemeEditorScreen` for both global and per-app overrides.
    - Integrated the `haze` library to implement glassmorphism (blur) effects on the reply text field and send button.
- **Settings & Persistence**:
    - Added `enableInlineReply` property to `IslandConfig` and updated `AppPreferences` to persist the new setting.
    - Added a toggle for Inline Reply in `IslandSettingsControl` and `OnboardingScreen`, including a warning about hidden actions when "Remove original notification" is enabled.
    - Integrated the Inline Reply customization entry into the `GlobalSettingsScreen`.
- **Localization & Metadata**:
    - Updated string resources across all supported locales (ES, FR, DE, CS, etc.) with terminology for the new feature and the v0.5.2 changelog.
    - Registered the new service, receiver, and `SYSTEM_ALERT_WINDOW` permission in `AndroidManifest.xml`.
- **Stability**:
    - Updated changelogs to reflect performance improvements, memory optimizations in the `NotificationListener`, and crash fixes for the Theme Creator and Widget Picker.

Fixes #171 
Fixes #140 