### PR TITLE
fix: Clamp progress percent to [0, 100] to prevent SystemUI crash

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/DownloadTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/DownloadTranslator.kt
@@ -53,11 +53,11 @@ class DownloadTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
         val textContent = (extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() ?: "")
 
         val textPercent = extractTextPercentage(title, textContent)
-        val percent = if (max > 0) {
+        val percent = (if (max > 0) {
             ((current.toFloat() / max.toFloat()) * 100).toInt()
         } else {
             textPercent ?: 0
-        }
+        }).coerceIn(0, 100)
         val isIndeterminate = indeterminate && textPercent == null
         val isTextFinished = finishKeywords.any { textContent.contains(it, ignoreCase = true) }
         val isFinished = percent >= 100 || isTextFinished

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt
@@ -55,11 +55,11 @@ class ProgressTranslator(context: Context, repo: ThemeRepository) : BaseTranslat
         val textContent = (extras.getCharSequence(Notification.EXTRA_TEXT)?.toString() ?: "")
 
         val textPercent = extractTextPercentage(title, textContent)
-        val percent = if (max > 0) {
+        val percent = (if (max > 0) {
             ((current.toFloat() / max.toFloat()) * 100).toInt()
         } else {
             textPercent ?: 0
-        }
+        }).coerceIn(0, 100)
         val isIndeterminate = indeterminate && textPercent == null
         val isTextFinished = finishKeywords.any { textContent.contains(it, ignoreCase = true) }
         val isFinished = percent >= 100 || isTextFinished


### PR DESCRIPTION
## Problem

When a third-party app (e.g. WhatsApp) sends a progress notification with a negative `EXTRA_PROGRESS` value (such as `-1` during chat backup initialization), `ProgressTranslator` and `DownloadTranslator` calculate a negative percent and pass it directly into the Dynamic Island JSON payload.

SystemUI's `CircularProgressBar.setProgress()` throws an `IllegalArgumentException` when it receives a value less than 0. Since this runs on the main thread, it causes a **fatal crash**. From the user's perspective, **SystemUI force-closes repeatedly**, resulting in a black screen or continuous UI restart loop until the offending notification is dismissed.

## Root Cause

```kotlin
// Before fix — no bounds checking
val percent = if (max > 0) {
    ((current.toFloat() / max.toFloat()) * 100).toInt()
} else {
    textPercent ?: 0
}
```

When `current = -1` and `max = 100`, this produces `percent = -1`, which is sent to SystemUI and triggers the crash.

## Fix

Applied `.coerceIn(0, 100)` to the calculated percent in both `ProgressTranslator` and `DownloadTranslator`, ensuring only valid progress values are forwarded to SystemUI regardless of what the source notification contains.

## Files Changed

- `app/src/main/java/com/d4viddf/hyperbridge/service/translators/ProgressTranslator.kt`
- `app/src/main/java/com/d4viddf/hyperbridge/service/translators/DownloadTranslator.kt`

## Crash Stack (from production logs)

```
java.lang.IllegalArgumentException: Progress value can not be less than 0
    at miui.systemui.widget.CircularProgressBar.setProgress()
    at miui.systemui.dynamicisland.module.IslandProgressViewHolder.bind()
    at miui.systemui.dynamicisland.module.IslandProgressViewHolder.updatePartial()
    at miui.systemui.dynamicisland.module.IslandCombineImageViewHolder.bind()
    at miui.systemui.dynamicisland.module.IslandModuleViewHolderAdapter.bindData()
```

## Tested On

- Redmi (tanzanite), HyperOS 3.0, Android 16
- Reproduced by sending a notification with `setProgress(100, -1, false)`
- Verified crash no longer occurs after the fix

Fixes #215 