### PR TITLE
feat: Add option to hide Permanent Island in landscape orientation

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
@@ -508,6 +508,7 @@ class AppPreferences(context: Context) {
 
     private val SHOW_PERMANENT_ISLAND = "show_permanent_island"
     private val PERMANENT_ISLAND_WIDTH = "permanent_island_width"
+    private val HIDE_PERMANENT_ISLAND_LANDSCAPE = "hide_permanent_island_landscape"
 
     val isPermanentIslandEnabledFlow: Flow<Boolean> = dao.getSettingFlow(SHOW_PERMANENT_ISLAND)
         .map { it?.toBoolean() ?: false }
@@ -515,12 +516,23 @@ class AppPreferences(context: Context) {
     val permanentIslandWidthFlow: Flow<Int> = dao.getSettingFlow(PERMANENT_ISLAND_WIDTH)
         .map { it?.toIntOrNull() ?: 0 }
 
+    val hidePermanentIslandLandscapeFlow: Flow<Boolean> = dao.getSettingFlow(HIDE_PERMANENT_ISLAND_LANDSCAPE)
+        .map { it?.toBoolean() ?: false }
+
     suspend fun setPermanentIslandEnabled(value: Boolean) {
         save(SHOW_PERMANENT_ISLAND, value.toString())
     }
 
     suspend fun setPermanentIslandWidth(value: Int) {
         save(PERMANENT_ISLAND_WIDTH, value.toString())
+    }
+
+    suspend fun setHidePermanentIslandLandscape(value: Boolean) {
+        save(HIDE_PERMANENT_ISLAND_LANDSCAPE, value.toString())
+    }
+
+    fun hidePermanentIslandLandscapeSync(): Boolean {
+        return memoryCache[HIDE_PERMANENT_ISLAND_LANDSCAPE]?.toBoolean() ?: false
     }
 
     // ========================================================================

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -524,8 +524,23 @@ class NotificationReaderService : NotificationListenerService() {
         }
     }
 
+    private fun logStateChange(isLandscape: Boolean) {
+        val orientation = if (isLandscape) "Landscape" else "Portrait"
+        val isIslandExhibited = activeIslands.isNotEmpty() || activeWidgets.isNotEmpty() || nativeIslands.isNotEmpty() || permanentIslandManager.isIslandActive()
+        val islandState = if (isIslandExhibited) "Showing Island" else "No Island"
+        Log.d(TAG, "State: $orientation | $islandState")
+    }
+
     private fun updatePermanentIsland() {
         permanentIslandManager.onActiveNotificationsChanged(activeIslands.size + activeWidgets.size, nativeIslands.isNotEmpty())
+        val isLandscape = resources.configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+        logStateChange(isLandscape)
+    }
+
+    override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+        super.onConfigurationChanged(newConfig)
+        permanentIslandManager.onOrientationChanged()
+        logStateChange(newConfig.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE)
     }
 
     // =========================================================================

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -28,14 +28,25 @@ class PermanentIslandManager(
     private var isPermanentIslandEnabled = false
     private var isIslandActive = false
     private var currentRealNotifications = 0
+
+    fun isIslandActive(): Boolean = isIslandActive
     private var hasNativeIsland = false
     private var currentWidth = 0
+    private var isHideInLandscapeEnabled = false
 
     init {
         scope.launch {
             preferences.isPermanentIslandEnabledFlow.collectLatest { enabled ->
                 if (isPermanentIslandEnabled != enabled) {
                     isPermanentIslandEnabled = enabled
+                    updateState()
+                }
+            }
+        }
+        scope.launch {
+            preferences.hidePermanentIslandLandscapeFlow.collectLatest { hide ->
+                if (isHideInLandscapeEnabled != hide) {
+                    isHideInLandscapeEnabled = hide
                     updateState()
                 }
             }
@@ -58,8 +69,19 @@ class PermanentIslandManager(
         updateState()
     }
 
+    fun onOrientationChanged() {
+        updateState()
+    }
     private fun updateState() {
-        if (isPermanentIslandEnabled && currentRealNotifications == 0 && !hasNativeIsland) {
+        val isLandscape = context.resources.configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+        val shouldShow = isPermanentIslandEnabled && 
+                         currentRealNotifications == 0 && 
+                         !hasNativeIsland && 
+                         !(isHideInLandscapeEnabled && isLandscape)
+
+        Log.d(TAG, "updateState: shouldShow=$shouldShow, isLandscape=$isLandscape, isHideInLandscapeEnabled=$isHideInLandscapeEnabled")
+
+        if (shouldShow) {
             if (!isIslandActive) {
                 dispatchPermanentIsland()
                 isIslandActive = true
@@ -71,7 +93,6 @@ class PermanentIslandManager(
             }
         }
     }
-
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
     private fun dispatchPermanentIsland() {
         try {

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/PermanentIslandConfigScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/PermanentIslandConfigScreen.kt
@@ -48,10 +48,12 @@ fun PermanentIslandConfigScreen(
     
     val isEnabled by prefs.isPermanentIslandEnabledFlow.collectAsState(initial = false)
     val islandWidth by prefs.permanentIslandWidthFlow.collectAsState(initial = 0)
+    val hideInLandscape by prefs.hidePermanentIslandLandscapeFlow.collectAsState(initial = false)
 
     PermanentIslandConfigContent(
         isEnabled = isEnabled,
         islandWidth = islandWidth,
+        hideInLandscape = hideInLandscape,
         onEnabledChange = { checked ->
             scope.launch {
                 prefs.setPermanentIslandEnabled(checked)
@@ -60,6 +62,11 @@ fun PermanentIslandConfigScreen(
         onWidthChange = { width ->
             scope.launch {
                 prefs.setPermanentIslandWidth(width)
+            }
+        },
+        onHideInLandscapeChange = { hide ->
+            scope.launch {
+                prefs.setHidePermanentIslandLandscape(hide)
             }
         },
         onBack = onBack
@@ -71,8 +78,10 @@ fun PermanentIslandConfigScreen(
 fun PermanentIslandConfigContent(
     isEnabled: Boolean,
     islandWidth: Int,
+    hideInLandscape: Boolean,
     onEnabledChange: (Boolean) -> Unit,
     onWidthChange: (Int) -> Unit,
+    onHideInLandscapeChange: (Boolean) -> Unit,
     onBack: () -> Unit
 ) {
     var sliderValue by androidx.compose.runtime.remember { androidx.compose.runtime.mutableFloatStateOf(0f) }
@@ -105,8 +114,6 @@ fun PermanentIslandConfigContent(
             PermanentIslandPreview(islandWidthValue = if (isDragging) sliderValue.toInt() else islandWidth)
 
             Spacer(Modifier.height(24.dp))
-            
-
 
             Card(
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
@@ -125,7 +132,6 @@ fun PermanentIslandConfigContent(
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
                             )
-
                         }
                         Switch(
                             checked = isEnabled,
@@ -152,6 +158,24 @@ fun PermanentIslandConfigContent(
                             },
                             valueRange = 0f..20f
                         )
+                        Spacer(Modifier.height(16.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.permanent_island_hide_landscape),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
+                                )
+                            }
+                            Switch(
+                                checked = hideInLandscape,
+                                onCheckedChange = onHideInLandscapeChange
+                            )
+                        }
                     }
                 }
             }
@@ -161,7 +185,6 @@ fun PermanentIslandConfigContent(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-
         }
     }
 }
@@ -173,9 +196,13 @@ fun PermanentIslandConfigScreenPreview() {
         PermanentIslandConfigContent(
             isEnabled = true,
             islandWidth = 10,
+            hideInLandscape = false,
             onEnabledChange = {},
             onWidthChange = {},
+            onHideInLandscapeChange = {},
             onBack = {}
         )
     }
 }
+
+

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,6 +45,7 @@
     <string name="permanent_island_desc">Mantenha a Ilha Dinâmica permanentemente visível na tela quando não houver notificações ativas.</string>
     <string name="permanent_island_screen_desc">Quando ativada, uma Ilha Dinâmica vazia será exibida permanentemente na sua tela. Ela se ocultará automaticamente quando notificações reais chegarem e reaparecerá quando todas as notificações forem apagadas. Ela não ficará visível na sua área de notificações.</string>
     <string name="permanent_island_width">Largura da ilha</string>
+    <string name="permanent_island_hide_landscape">Ocultar na Horizontal</string>
     <string name="group_about">Sobre</string>
     <string name="developer">Desenvolvedor</string>
     <string name="developer_subtitle">Visite d4viddf.com</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="permanent_island_desc">Keep the Dynamic Island permanently visible on screen when there are no active notifications.</string>
     <string name="permanent_island_screen_desc">When enabled, an empty Dynamic Island will be shown permanently on your screen. It will automatically hide when real notifications arrive and reappear when all notifications are cleared. It will not be visible in your notification shade.</string>
     <string name="permanent_island_width">Island Width</string>
+    <string name="permanent_island_hide_landscape">Hide in Landscape</string>
 
     <string name="group_about">About</string>
     <string name="developer">Developer</string>


### PR DESCRIPTION
### Description
This PR introduces a new toggle setting in the Permanent Island configuration screen to allow users to automatically hide the empty permanent island when the device is in landscape mode.

### Motivation
When playing games, watching videos, or using full-screen apps in landscape mode, the permanent empty island can overlay content unnecessarily and cause visual clutter. Hiding it in landscape improves the user experience during full-screen or landscape-specific activities.

### Changes
- Added a `hidePermanentIslandLandscape` preference key and synchronous/reactive settings flows.
- Implemented a configuration Switch in the Permanent Island Settings UI.
- Updated `PermanentIslandManager` to dynamically evaluate the device configuration and hide the permanent island when landscape orientation is detected.
- Added real-time orientation tracking in `NotificationReaderService` to update the permanent island state immediately when the device rotates.

---

### Visual Changes (UI/UX)

| Settings Screen | Vertical Mode (Active Island) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/8ee97fc0-c5c4-4064-be56-2ec011e4ab27" width="250" /> | <img src="https://github.com/user-attachments/assets/30cba4a0-b9aa-4a8a-ac61-0a98b55d8b17" width="250" /> |

| Landscape (Toggle ON - Island Hidden) | Landscape (Toggle OFF - Island Shown) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/b7125a80-905b-4678-95e7-c5d39a3f1366" width="400" />  | <img src="https://github.com/user-attachments/assets/9111cba6-5019-42d9-bac1-401ba009b165" width="400" /> |
