### PR TITLE
fix: validate highlightColor before passing to SystemUI

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/service/translators/BaseTranslator.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/translators/BaseTranslator.kt
@@ -75,13 +75,13 @@ abstract class BaseTranslator(
             // A. Specific Color Override
             val overrideColor = override?.highlightColor
             if (!overrideColor.isNullOrEmpty()) {
-                return overrideColor
+                return overrideColor.toSafeColorHex(defaultHex)
             }
 
             // B. App-Specific "Use App Colors"
             // If explicit true -> extract. If explicit false -> skip extraction (fall to global).
             if (override?.useAppColors == true) {
-                return getAppBrandColor(pkg) ?: theme.global.highlightColor ?: defaultHex
+                return (getAppBrandColor(pkg) ?: theme.global.highlightColor ?: defaultHex).toSafeColorHex(defaultHex)
             }
         }
 
@@ -89,11 +89,26 @@ abstract class BaseTranslator(
         // Only run if app override didn't explicitly disable it (useAppColors != false)
         val appOverrideDisabled = theme.apps[pkg]?.useAppColors == false
         if (theme.global.useAppColors && !appOverrideDisabled && pkg != null) {
-            return getAppBrandColor(pkg) ?: theme.global.highlightColor ?: defaultHex
+            return (getAppBrandColor(pkg) ?: theme.global.highlightColor ?: defaultHex).toSafeColorHex(defaultHex)
         }
 
         // 3. Global Theme Highlight -> Default Fallback
-        return theme.global.highlightColor ?: defaultHex
+        return (theme.global.highlightColor ?: defaultHex).toSafeColorHex(defaultHex)
+    }
+
+    /**
+     * Validates that a color string can be parsed by [android.graphics.Color.parseColor].
+     * Returns the original string if valid, or [fallback] if parsing fails.
+     * This prevents SystemUI crashes caused by invalid color values in theme configs.
+     */
+    private fun String.toSafeColorHex(fallback: String): String {
+        return try {
+            Color.parseColor(this)
+            this
+        } catch (_: IllegalArgumentException) {
+            Log.w("BaseTranslator", "Invalid highlight color \"$this\", falling back to \"$fallback\"")
+            fallback
+        }
     }
 
     private fun getAppBrandColor(pkg: String): String? {


### PR DESCRIPTION
## Summary

Fixes a **SystemUI crash** caused by invalid `highlightColor` values in theme configurations being passed directly to `Color.parseColor()` in HyperOS's DynamicIsland.

## Problem

When a theme (imported `.hbr` file or legacy config) contains an invalid `highlight_color` value (e.g. `"013"` without `#` prefix), `resolveColor()` returns it as-is. SystemUI's `DynamicIslandBaseContentView.updateDarkLightMode()` then calls `highlightColor.toColorInt()`, which throws:

```
FATAL EXCEPTION: main
Process: com.android.systemui
java.lang.IllegalArgumentException: Unknown color
    at android.graphics.Color.parseColor(Color.java:1402)
    at miui.systemui.dynamicisland.window.content.DynamicIslandBaseContentView.updateDarkLightMode
```

This crash only triggers when:
- The island region background is dark (`isLight = false`)
- The island is in BigIsland state (not Expanded)
- `highlightColor` is non-empty but unparseable

## Fix

Added `toSafeColorHex()` validation at all return paths of `resolveColor()` in `BaseTranslator`. If `Color.parseColor()` throws `IllegalArgumentException`, it falls back to the provided default hex value and logs a warning.

## What was tested

- Injected a theme with `"highlight_color": "013"` (the exact value from the original bugreport)
- Sent notifications with dark wallpaper active
- Confirmed SystemUI no longer crashes
- Confirmed logcat shows: `W/BaseTranslator: Invalid highlight color "013", falling back to "#FFFFFF"`