### PR TITLE
fix: skip group summaries that duplicate live conversation notifications

### DIFF
--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -1218,6 +1218,22 @@ class NotificationReaderService : NotificationListenerService() {
             val type = detectNotificationType(sbn)
             if (type != NotificationType.MESSAGE) return true
             if (text.isEmpty() || title.isEmpty()) return true
+            // A summary with live children is a duplicate: messaging apps post the real
+            // per-conversation notification plus an "N new messages" summary. With
+            // "remove original notification" disabled the summary survives and would
+            // become a second island. Only islandify a summary that stands alone
+            // (some apps post only the summary).
+            val group = notification.group
+            if (group != null) {
+                val hasLiveChild = try {
+                    activeNotifications?.any {
+                        it.packageName == pkg && it.key != sbn.key &&
+                            (it.notification.flags and Notification.FLAG_GROUP_SUMMARY) == 0 &&
+                            it.notification.group == group
+                    } == true
+                } catch (_: Exception) { false }
+                if (hasLiveChild) return true
+            }
         }
 
         return false


### PR DESCRIPTION
## Problem

Messaging apps produce a duplicate island. WhatsApp (and Telegram, etc.) post each incoming message twice:

- the real per-conversation notification (contact photo, reply/mark-as-read actions), and
- a group summary ("N new messages").

`isJunkNotification` already drops most summaries, but lets MESSAGE-type summaries with a title and text through — which is exactly what WhatsApp's summary looks like. Both notifications get islandified, so once a conversation has more than one unread message you get two islands:

- island 1: the conversation (correct)
- island 2: "N new messages" (duplicate of island 1)

## Fix

Treat a MESSAGE group summary as junk when a non-summary notification from the same package and group is still active. A summary that stands alone still gets islandified, so apps that only post a summary keep working.

If the summary happens to arrive before its first child, it can still slip through for that one burst; the existing island TTL cleans it up, and every subsequent update is filtered.

## Testing

Verified on-device (HyperOS 3, Redmi Note 15 Pro, WhatsApp): a multi-message conversation now produces a single island for the conversation and none for the summary; a standalone summary-only notification still islandifies.

---
As with #243, this was developed with AI assistance (Claude Code) and verified on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)