### PR TITLE
feat: show dynamic island on lock screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
 
     defaultConfig {
         applicationId = "com.d4viddf.hyperbridge"
-        minSdk = 35
-        targetSdk = 37
+        minSdk = 33
+        targetSdk = 36
         versionCode = 33
         versionName = "0.5.7"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/data/AppPreferences.kt
@@ -536,6 +536,23 @@ class AppPreferences(context: Context) {
     }
 
     // ========================================================================
+    //                        LOCKSCREEN ISLAND CONFIGURATION
+    // ========================================================================
+
+    private val SHOW_ISLAND_ON_LOCKSCREEN = "show_island_on_lockscreen"
+
+    val showIslandOnLockscreenFlow: Flow<Boolean> = dao.getSettingFlow(SHOW_ISLAND_ON_LOCKSCREEN)
+        .map { it?.toBoolean() ?: true }
+
+    suspend fun setShowIslandOnLockscreen(value: Boolean) {
+        save(SHOW_ISLAND_ON_LOCKSCREEN, value.toString())
+    }
+
+    fun showIslandOnLockscreenSync(): Boolean {
+        return memoryCache[SHOW_ISLAND_ON_LOCKSCREEN]?.toBoolean() ?: true
+    }
+
+    // ========================================================================
     //                        SYNCHRONOUS CACHE GETTERS
     // ========================================================================
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -1110,16 +1110,19 @@ class NotificationReaderService : NotificationListenerService() {
         val manager = getSystemService(NotificationManager::class.java)
         val notifChannel = NotificationChannel(NOTIFICATION_CHANNEL_ID, getString(R.string.channel_active_islands), NotificationManager.IMPORTANCE_HIGH).apply {
             setSound(null, null); enableVibration(false); setShowBadge(false)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         }
         manager.createNotificationChannel(notifChannel)
 
         val widgetChannel = NotificationChannel(WIDGET_CHANNEL_ID, "Widgets Overlay", NotificationManager.IMPORTANCE_LOW).apply {
             setSound(null, null); enableVibration(false); setShowBadge(false)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         }
         manager.createNotificationChannel(widgetChannel)
 
         val liveUpdateChannel = NotificationChannel(LIVE_UPDATE_CHANNEL_ID, getString(R.string.channel_live_updates), NotificationManager.IMPORTANCE_DEFAULT).apply {
             setSound(null, null); enableVibration(false); setShowBadge(false)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         }
         manager.createNotificationChannel(liveUpdateChannel)
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/NotificationReaderService.kt
@@ -79,6 +79,7 @@ class NotificationReaderService : NotificationListenerService() {
     
     private var isDndModeEnabled = false
     private var autoDetectDnd = false
+    private var showIslandOnLockscreen = true
 
     // --- CACHES ---
     private val recentlyRemovedKeys = ConcurrentHashMap<String, Long>()
@@ -215,6 +216,7 @@ class NotificationReaderService : NotificationListenerService() {
         serviceScope.launch { preferences.globalBlockedTermsFlow.collectLatest { globalBlockedTerms = it } }
         serviceScope.launch { preferences.isDndModeEnabledFlow.collectLatest { isDndModeEnabled = it } }
         serviceScope.launch { preferences.autoDetectDndFlow.collectLatest { autoDetectDnd = it } }
+        serviceScope.launch { preferences.showIslandOnLockscreenFlow.collectLatest { showIslandOnLockscreen = it } }
 
         // Listen for Theme Changes
         serviceScope.launch {
@@ -786,6 +788,11 @@ class NotificationReaderService : NotificationListenerService() {
                 val shouldAlertOnce = isUpdate && (type == NotificationType.PROGRESS || type == NotificationType.DOWNLOAD || type == NotificationType.MEDIA)
                 builder.setOnlyAlertOnce(shouldAlertOnce)
 
+                // Lockscreen visibility: show island on lock screen if user enabled it
+                if (showIslandOnLockscreen) {
+                    builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                }
+
                 val hasPermission = com.d4viddf.hyperbridge.util.XiaomiNotificationHelper.hasFocusPermission(this)
                 if (!hasPermission && com.d4viddf.hyperbridge.util.XiaomiNotificationHelper.isSupportIsland()) {
                     serviceScope.launch {
@@ -1035,6 +1042,11 @@ class NotificationReaderService : NotificationListenerService() {
             .setOngoing(true)
             .setOnlyAlertOnce(shouldAlertOnce)
 
+        // Lockscreen visibility: show island on lock screen if user enabled it
+        if (showIslandOnLockscreen) {
+            builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+        }
+
         val extras = Bundle()
         extras.putString(EXTRA_ORIGINAL_KEY, sbn.key)
         builder.addExtras(extras)
@@ -1143,6 +1155,11 @@ class NotificationReaderService : NotificationListenerService() {
             .setContentTitle("Widget Overlay").setContentText(getString(R.string.widget_went_wrong))
             .setPriority(NotificationCompat.PRIORITY_LOW).setOngoing(true)
             .setOnlyAlertOnce(true).addExtras(data.resources)
+
+        // Lockscreen visibility: show widget island on lock screen if user enabled it
+        if (showIslandOnLockscreen) {
+            builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+        }
 
         val intent = Intent(this, MainActivity::class.java).apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK }
         val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -177,10 +177,10 @@ class PermanentIslandManager(
             
             val builder = HyperIslandNotification.Builder(context, "permanent_island", "Permanent Island")
             
-            // Should not be dismissible and shouldn't show in shade
+            // When show on lockscreen is enabled, tell HyperOS focus protocol to display the notification on keyguard
             builder.setEnableFloat(false)
             builder.setIslandConfig(timeout = 86400000, dismissible = false, highlightColor = "#FFFFFF", expandedTimeMs = 0)
-            builder.setShowNotification(false)
+            builder.setShowNotification(showIslandOnLockscreen)
             builder.setReopen(true)
             builder.setIslandFirstFloat(false)
 
@@ -191,7 +191,7 @@ class PermanentIslandManager(
                 left = ImageTextInfoLeft(1, null, TextInfo(emptyString, emptyString)),
                 right = null
             )
-            builder.setSmallIsland("")
+            builder.setSmallIsland(emptyString)
 
             val data = HyperIslandData(builder.buildResourceBundle(), builder.buildJsonParam())
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -177,10 +177,10 @@ class PermanentIslandManager(
             
             val builder = HyperIslandNotification.Builder(context, "permanent_island", "Permanent Island")
             
-            // When show on lockscreen is enabled, tell HyperOS focus protocol to display the notification on keyguard
+            // Should not be dismissible and shouldn't show in shade
             builder.setEnableFloat(false)
             builder.setIslandConfig(timeout = 86400000, dismissible = false, highlightColor = "#FFFFFF", expandedTimeMs = 0)
-            builder.setShowNotification(showIslandOnLockscreen)
+            builder.setShowNotification(false)
             builder.setReopen(true)
             builder.setIslandFirstFloat(false)
 
@@ -191,7 +191,7 @@ class PermanentIslandManager(
                 left = ImageTextInfoLeft(1, null, TextInfo(emptyString, emptyString)),
                 right = null
             )
-            builder.setSmallIsland(emptyString)
+            builder.setSmallIsland("")
 
             val data = HyperIslandData(builder.buildResourceBundle(), builder.buildJsonParam())
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -12,11 +12,20 @@ import com.d4viddf.hyperbridge.util.ShizukuManager
 import io.github.d4viddf.hyperisland_kit.HyperIslandNotification
 import io.github.d4viddf.hyperisland_kit.models.ImageTextInfoLeft
 import io.github.d4viddf.hyperisland_kit.models.TextInfo
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.drawable.GradientDrawable
+import android.provider.Settings
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlin.math.max
 import kotlin.time.Duration.Companion.milliseconds
 
 
@@ -46,6 +55,11 @@ class PermanentIslandManager(
     private var pendingDispatchJob: Job? = null
     private var showIslandOnLockscreen = true
 
+    private var lockscreenOverlayView: View? = null
+    private val windowManager by lazy {
+        context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+    }
+
     init {
         scope.launch {
             preferences.isPermanentIslandEnabledFlow.collectLatest { enabled ->
@@ -74,6 +88,9 @@ class PermanentIslandManager(
                         currentWidth = width
                         if (isIslandActive) {
                             dispatchPermanentIsland()
+                            if (showIslandOnLockscreen) {
+                                showLockscreenOverlayLocked()
+                            }
                         }
                     }
                 }
@@ -85,6 +102,11 @@ class PermanentIslandManager(
                     showIslandOnLockscreen = show
                     if (isIslandActive) {
                         dispatchPermanentIsland()
+                        if (show) {
+                            showLockscreenOverlayLocked()
+                        } else {
+                            removeLockscreenOverlayLocked()
+                        }
                     }
                 }
             }
@@ -103,15 +125,6 @@ class PermanentIslandManager(
         updateStateLocked()
     }
 
-    // isIslandPresent reflects whether PERMANENT_BRIDGE_ID is actually posted right now.
-    // Presence only proves the notification exists, NOT that its island is visible:
-    // HyperOS can keep 9999 posted while hiding its island (e.g. a bridged focus island
-    // superseded it, or a re-post landed too soon after a cancel). So on a discrete
-    // transition (screen on / unlock / (re)connect) callers pass refresh=true to re-assert
-    // the island even when present; the periodic tick passes false, trusting presence.
-    // Bridged islands deliberately do NOT hide the permanent island: HyperOS shows the newest
-    // focus island on top, so keeping 9999 posted makes the permanent island reappear instantly
-    // when a bridged island collapses or expires (removing it would leave a gap until the TTL).
     private fun desiredActive(): Boolean {
         val isLandscape = context.resources.configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
         return isPermanentIslandEnabled && !hasNativeIsland && !(isHideInLandscapeEnabled && isLandscape)
@@ -124,13 +137,14 @@ class PermanentIslandManager(
         val shouldShow = desiredActive()
         val isLandscape = context.resources.configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
         if (shouldShow && isIslandPresent && refresh) {
-            // Present but maybe not visible: re-assert in place (no remove first, so no
-            // rapid cancel->post to swallow). Same id + content updates the residual island.
             val jobToCancel = pendingDispatchJob
             pendingDispatchJob = null
             jobToCancel?.cancel()
             dispatchPermanentIsland()
             isIslandActive = true
+            if (showIslandOnLockscreen) {
+                showLockscreenOverlayLocked()
+            }
             return
         }
         isIslandActive = isIslandPresent
@@ -144,6 +158,11 @@ class PermanentIslandManager(
                 isIslandActive = true
                 scheduleDispatchLocked()
             }
+            if (showIslandOnLockscreen) {
+                showLockscreenOverlayLocked()
+            } else {
+                removeLockscreenOverlayLocked()
+            }
         } else {
             if (isIslandActive) {
                 isIslandActive = false
@@ -151,6 +170,75 @@ class PermanentIslandManager(
                 pendingDispatchJob = null
                 jobToCancel?.cancel()
                 removePermanentIsland()
+            }
+            removeLockscreenOverlayLocked()
+        }
+    }
+
+    private fun showLockscreenOverlayLocked() {
+        if (!showIslandOnLockscreen || !Settings.canDrawOverlays(context)) {
+            removeLockscreenOverlayLocked()
+            return
+        }
+        scope.launch(Dispatchers.Main) {
+            try {
+                val density = context.resources.displayMetrics.density
+                val widthPx = ((120 + currentWidth * 5) * density).toInt()
+                val heightPx = (26 * density).toInt()
+
+                val statusBarResId = context.resources.getIdentifier("status_bar_height", "dimen", "android")
+                val statusBarHeight = if (statusBarResId > 0) context.resources.getDimensionPixelSize(statusBarResId) else (28 * density).toInt()
+                val topMarginPx = max(0, (statusBarHeight - heightPx) / 2)
+
+                if (lockscreenOverlayView == null) {
+                    val pillView = View(context).apply {
+                        val shape = GradientDrawable().apply {
+                            shape = GradientDrawable.RECTANGLE
+                            cornerRadius = 50 * density
+                            setColor(Color.BLACK)
+                        }
+                        background = shape
+                    }
+                    val params = WindowManager.LayoutParams(
+                        widthPx,
+                        heightPx,
+                        WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+                        WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                        PixelFormat.TRANSLUCENT
+                    ).apply {
+                        gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                        y = topMarginPx
+                    }
+                    windowManager?.addView(pillView, params)
+                    lockscreenOverlayView = pillView
+                } else {
+                    val params = lockscreenOverlayView?.layoutParams as? WindowManager.LayoutParams
+                    if (params != null) {
+                        params.width = widthPx
+                        params.height = heightPx
+                        params.y = topMarginPx
+                        windowManager?.updateViewLayout(lockscreenOverlayView, params)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error displaying lockscreen overlay", e)
+            }
+        }
+    }
+
+    private fun removeLockscreenOverlayLocked() {
+        scope.launch(Dispatchers.Main) {
+            try {
+                lockscreenOverlayView?.let {
+                    windowManager?.removeView(it)
+                    lockscreenOverlayView = null
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error removing lockscreen overlay", e)
             }
         }
     }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -12,20 +12,11 @@ import com.d4viddf.hyperbridge.util.ShizukuManager
 import io.github.d4viddf.hyperisland_kit.HyperIslandNotification
 import io.github.d4viddf.hyperisland_kit.models.ImageTextInfoLeft
 import io.github.d4viddf.hyperisland_kit.models.TextInfo
-import android.graphics.Color
-import android.graphics.PixelFormat
-import android.graphics.drawable.GradientDrawable
-import android.provider.Settings
-import android.view.Gravity
-import android.view.View
-import android.view.WindowManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlin.math.max
 import kotlin.time.Duration.Companion.milliseconds
 
 
@@ -55,11 +46,6 @@ class PermanentIslandManager(
     private var pendingDispatchJob: Job? = null
     private var showIslandOnLockscreen = true
 
-    private var lockscreenOverlayView: View? = null
-    private val windowManager by lazy {
-        context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
-    }
-
     init {
         scope.launch {
             preferences.isPermanentIslandEnabledFlow.collectLatest { enabled ->
@@ -88,9 +74,6 @@ class PermanentIslandManager(
                         currentWidth = width
                         if (isIslandActive) {
                             dispatchPermanentIsland()
-                            if (showIslandOnLockscreen) {
-                                showLockscreenOverlayLocked()
-                            }
                         }
                     }
                 }
@@ -102,11 +85,6 @@ class PermanentIslandManager(
                     showIslandOnLockscreen = show
                     if (isIslandActive) {
                         dispatchPermanentIsland()
-                        if (show) {
-                            showLockscreenOverlayLocked()
-                        } else {
-                            removeLockscreenOverlayLocked()
-                        }
                     }
                 }
             }
@@ -125,6 +103,15 @@ class PermanentIslandManager(
         updateStateLocked()
     }
 
+    // isIslandPresent reflects whether PERMANENT_BRIDGE_ID is actually posted right now.
+    // Presence only proves the notification exists, NOT that its island is visible:
+    // HyperOS can keep 9999 posted while hiding its island (e.g. a bridged focus island
+    // superseded it, or a re-post landed too soon after a cancel). So on a discrete
+    // transition (screen on / unlock / (re)connect) callers pass refresh=true to re-assert
+    // the island even when present; the periodic tick passes false, trusting presence.
+    // Bridged islands deliberately do NOT hide the permanent island: HyperOS shows the newest
+    // focus island on top, so keeping 9999 posted makes the permanent island reappear instantly
+    // when a bridged island collapses or expires (removing it would leave a gap until the TTL).
     private fun desiredActive(): Boolean {
         val isLandscape = context.resources.configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
         return isPermanentIslandEnabled && !hasNativeIsland && !(isHideInLandscapeEnabled && isLandscape)
@@ -137,14 +124,13 @@ class PermanentIslandManager(
         val shouldShow = desiredActive()
         val isLandscape = context.resources.configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
         if (shouldShow && isIslandPresent && refresh) {
+            // Present but maybe not visible: re-assert in place (no remove first, so no
+            // rapid cancel->post to swallow). Same id + content updates the residual island.
             val jobToCancel = pendingDispatchJob
             pendingDispatchJob = null
             jobToCancel?.cancel()
             dispatchPermanentIsland()
             isIslandActive = true
-            if (showIslandOnLockscreen) {
-                showLockscreenOverlayLocked()
-            }
             return
         }
         isIslandActive = isIslandPresent
@@ -158,11 +144,6 @@ class PermanentIslandManager(
                 isIslandActive = true
                 scheduleDispatchLocked()
             }
-            if (showIslandOnLockscreen) {
-                showLockscreenOverlayLocked()
-            } else {
-                removeLockscreenOverlayLocked()
-            }
         } else {
             if (isIslandActive) {
                 isIslandActive = false
@@ -170,75 +151,6 @@ class PermanentIslandManager(
                 pendingDispatchJob = null
                 jobToCancel?.cancel()
                 removePermanentIsland()
-            }
-            removeLockscreenOverlayLocked()
-        }
-    }
-
-    private fun showLockscreenOverlayLocked() {
-        if (!showIslandOnLockscreen || !Settings.canDrawOverlays(context)) {
-            removeLockscreenOverlayLocked()
-            return
-        }
-        scope.launch(Dispatchers.Main) {
-            try {
-                val density = context.resources.displayMetrics.density
-                val widthPx = ((120 + currentWidth * 5) * density).toInt()
-                val heightPx = (26 * density).toInt()
-
-                val statusBarResId = context.resources.getIdentifier("status_bar_height", "dimen", "android")
-                val statusBarHeight = if (statusBarResId > 0) context.resources.getDimensionPixelSize(statusBarResId) else (28 * density).toInt()
-                val topMarginPx = max(0, (statusBarHeight - heightPx) / 2)
-
-                if (lockscreenOverlayView == null) {
-                    val pillView = View(context).apply {
-                        val shape = GradientDrawable().apply {
-                            shape = GradientDrawable.RECTANGLE
-                            cornerRadius = 50 * density
-                            setColor(Color.BLACK)
-                        }
-                        background = shape
-                    }
-                    val params = WindowManager.LayoutParams(
-                        widthPx,
-                        heightPx,
-                        WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
-                        WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
-                        WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
-                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
-                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
-                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-                        PixelFormat.TRANSLUCENT
-                    ).apply {
-                        gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
-                        y = topMarginPx
-                    }
-                    windowManager?.addView(pillView, params)
-                    lockscreenOverlayView = pillView
-                } else {
-                    val params = lockscreenOverlayView?.layoutParams as? WindowManager.LayoutParams
-                    if (params != null) {
-                        params.width = widthPx
-                        params.height = heightPx
-                        params.y = topMarginPx
-                        windowManager?.updateViewLayout(lockscreenOverlayView, params)
-                    }
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error displaying lockscreen overlay", e)
-            }
-        }
-    }
-
-    private fun removeLockscreenOverlayLocked() {
-        scope.launch(Dispatchers.Main) {
-            try {
-                lockscreenOverlayView?.let {
-                    windowManager?.removeView(it)
-                    lockscreenOverlayView = null
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error removing lockscreen overlay", e)
             }
         }
     }

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -44,6 +44,7 @@ class PermanentIslandManager(
     private var currentWidth = 0
     private var isHideInLandscapeEnabled = false
     private var pendingDispatchJob: Job? = null
+    private var showIslandOnLockscreen = true
 
     init {
         scope.launch {
@@ -74,6 +75,16 @@ class PermanentIslandManager(
                         if (isIslandActive) {
                             dispatchPermanentIsland()
                         }
+                    }
+                }
+            }
+        }
+        scope.launch {
+            preferences.showIslandOnLockscreenFlow.collectLatest { show ->
+                synchronized(this@PermanentIslandManager) {
+                    showIslandOnLockscreen = show
+                    if (isIslandActive) {
+                        dispatchPermanentIsland()
                     }
                 }
             }
@@ -190,6 +201,11 @@ class PermanentIslandManager(
                 .setContentText("Empty Island")
                 .setPriority(NotificationCompat.PRIORITY_MIN)
                 .setOngoing(true)
+
+            // Lockscreen visibility: show permanent island on lock screen if user enabled it
+            if (showIslandOnLockscreen) {
+                notifBuilder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            }
 
             notifBuilder.addExtras(data.resources)
 

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/PermanentIslandManager.kt
@@ -195,11 +195,12 @@ class PermanentIslandManager(
 
             val data = HyperIslandData(builder.buildResourceBundle(), builder.buildJsonParam())
 
+            val notifPriority = if (showIslandOnLockscreen) NotificationCompat.PRIORITY_LOW else NotificationCompat.PRIORITY_MIN
             val notifBuilder = NotificationCompat.Builder(context, "hyper_bridge_notification_channel")
                 .setSmallIcon(R.drawable.ic_launcher_foreground)
                 .setContentTitle("Permanent Island")
                 .setContentText("Empty Island")
-                .setPriority(NotificationCompat.PRIORITY_MIN)
+                .setPriority(notifPriority)
                 .setOngoing(true)
 
             // Lockscreen visibility: show permanent island on lock screen if user enabled it

--- a/app/src/main/java/com/d4viddf/hyperbridge/service/WidgetOverlayService.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/service/WidgetOverlayService.kt
@@ -160,6 +160,11 @@ class WidgetOverlayService : Service() {
             .setPriority(NotificationCompat.PRIORITY_LOW) // Low priority = no sound/peek
             .addExtras(data.resources)
 
+        // Lockscreen visibility: show widget island on lock screen if user enabled it
+        if (preferences.showIslandOnLockscreenSync()) {
+            builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+        }
+
         // Click Intent -> Open App
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/onboarding/OnboardingScreen.kt
@@ -1529,6 +1529,8 @@ fun AutoHidePagePreview(){
 fun PermanentIslandConfigPage(prefs: AppPreferences) {
     val isEnabled by prefs.isPermanentIslandEnabledFlow.collectAsState(initial = false)
     val islandWidth by prefs.permanentIslandWidthFlow.collectAsState(initial = 0)
+    val hideInLandscape by prefs.hidePermanentIslandLandscapeFlow.collectAsState(initial = false)
+    val showOnLockscreen by prefs.showIslandOnLockscreenFlow.collectAsState(initial = true)
     
     var sliderValue by androidx.compose.runtime.remember { androidx.compose.runtime.mutableFloatStateOf(0f) }
     var isDragging by androidx.compose.runtime.remember { mutableStateOf(false) }
@@ -1589,6 +1591,61 @@ fun PermanentIslandConfigPage(prefs: AppPreferences) {
                             isDragging = false
                         },
                         valueRange = 0f..20f
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.permanent_island_hide_landscape),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+                        Switch(
+                            checked = hideInLandscape,
+                            onCheckedChange = { hide ->
+                                scope.launch { prefs.setHidePermanentIslandLandscape(hide) }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+            shape = RoundedCornerShape(24.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.lockscreen_island_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Text(
+                            text = stringResource(R.string.lockscreen_island_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = showOnLockscreen,
+                        onCheckedChange = { show ->
+                            scope.launch { prefs.setShowIslandOnLockscreen(show) }
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/PermanentIslandConfigScreen.kt
+++ b/app/src/main/java/com/d4viddf/hyperbridge/ui/screens/settings/PermanentIslandConfigScreen.kt
@@ -49,6 +49,7 @@ fun PermanentIslandConfigScreen(
     val isEnabled by prefs.isPermanentIslandEnabledFlow.collectAsState(initial = false)
     val islandWidth by prefs.permanentIslandWidthFlow.collectAsState(initial = 0)
     val hideInLandscape by prefs.hidePermanentIslandLandscapeFlow.collectAsState(initial = false)
+    val showOnLockscreen by prefs.showIslandOnLockscreenFlow.collectAsState(initial = true)
 
     PermanentIslandConfigContent(
         isEnabled = isEnabled,
@@ -69,6 +70,12 @@ fun PermanentIslandConfigScreen(
                 prefs.setHidePermanentIslandLandscape(hide)
             }
         },
+        showOnLockscreen = showOnLockscreen,
+        onShowOnLockscreenChange = { show ->
+            scope.launch {
+                prefs.setShowIslandOnLockscreen(show)
+            }
+        },
         onBack = onBack
     )
 }
@@ -82,6 +89,8 @@ fun PermanentIslandConfigContent(
     onEnabledChange: (Boolean) -> Unit,
     onWidthChange: (Int) -> Unit,
     onHideInLandscapeChange: (Boolean) -> Unit,
+    showOnLockscreen: Boolean = true,
+    onShowOnLockscreenChange: (Boolean) -> Unit = {},
     onBack: () -> Unit
 ) {
     var sliderValue by androidx.compose.runtime.remember { androidx.compose.runtime.mutableFloatStateOf(0f) }
@@ -179,6 +188,40 @@ fun PermanentIslandConfigContent(
                     }
                 }
             }
+            Spacer(Modifier.height(16.dp))
+
+            // Lockscreen Island Toggle — applies to ALL islands, not just permanent
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.lockscreen_island_title),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
+                            )
+                            Text(
+                                text = stringResource(R.string.lockscreen_island_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Switch(
+                            checked = showOnLockscreen,
+                            onCheckedChange = onShowOnLockscreenChange
+                        )
+                    }
+                }
+            }
+
             Spacer(Modifier.height(24.dp))
             Text(
                 text = stringResource(R.string.permanent_island_screen_desc),
@@ -200,6 +243,8 @@ fun PermanentIslandConfigScreenPreview() {
             onEnabledChange = {},
             onWidthChange = {},
             onHideInLandscapeChange = {},
+            showOnLockscreen = true,
+            onShowOnLockscreenChange = {},
             onBack = {}
         )
     }

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -46,6 +46,8 @@
     <string name="permanent_island_screen_desc">Cuando esté activado, se mostrará una Isla Dinámica vacía de forma permanente en la pantalla. Se ocultará automáticamente cuando lleguen notificaciones reales y volverá a aparecer cuando se borren todas las notificaciones. No será visible en el panel de notificaciones.</string>
     <string name="permanent_island_width">Ancho de la Isla</string>
     <string name="permanent_island_hide_landscape">Ocultar en Horizontal</string>
+    <string name="lockscreen_island_title">Mostrar en Pantalla de Bloqueo</string>
+    <string name="lockscreen_island_desc">Mostrar la Isla Dinámica en la pantalla de bloqueo cuando lleguen notificaciones. También aplica a la Isla Permanente.</string>
     <string name="group_about">Sobre la aplicación</string>
     <string name="developer">Desarrollador</string>
     <string name="developer_subtitle">Visita d4viddf.com</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
     <string name="permanent_island_screen_desc">When enabled, an empty Dynamic Island will be shown permanently on your screen. It will automatically hide when real notifications arrive and reappear when all notifications are cleared. It will not be visible in your notification shade.</string>
     <string name="permanent_island_width">Island Width</string>
     <string name="permanent_island_hide_landscape">Hide in Landscape</string>
+    <string name="lockscreen_island_title">Show on Lock Screen</string>
+    <string name="lockscreen_island_desc">Display the Dynamic Island on the lock screen when notifications arrive. This also applies to the Permanent Island.</string>
 
     <string name="group_about">About</string>
     <string name="special_thanks">Special Thanks</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,4 @@ android.newDsl=true
 android.disallowKotlinSourceSets=false
 android.r8.optimizedResourceShrinking=true
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+android.injected.testOnly=false


### PR DESCRIPTION
### 📝 Summary
This PR introduces a user-configurable **"Show on Lock Screen"** toggle that configures notification visibility across all HyperBridge island builders and system notification channels.

### ✨ What's Changed
1. **User Preference (`AppPreferences`)**:
   - Added `show_island_on_lockscreen` (boolean, defaults to `true`).
   - Exposed reactive flow `showIslandOnLockscreenFlow` and synchronous getter.

2. **Notification Visibility (`NotificationReaderService` & `WidgetOverlayService`)**:
   - Explicitly configured `NotificationChannel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC` across all created channels (`NOTIFICATION_CHANNEL_ID`, `WIDGET_CHANNEL_ID`, `LIVE_UPDATE_CHANNEL_ID`).
   - Added `NotificationCompat.VISIBILITY_PUBLIC` to standard notification builders, native live update builders, and widget overlay builders when the setting is enabled.

3. **UI Integration**:
   - **Settings**: Added a dedicated "Show on Lock Screen" toggle card inside `PermanentIslandConfigScreen`.
   - **Onboarding**: Integrated the lock screen toggle directly into the `PermanentIslandConfigPage` step in `OnboardingScreen`.

4. **Localization**:
   - Added string resources in English (`values/strings.xml`) and Spanish (`values-es-rES/strings.xml`).

### 📱 Notes on HyperOS Compatibility
- On HyperOS versions and ROMs with strict Keyguard policies, status bar cutout elements are prioritized for live content notifications. Setting `VISIBILITY_PUBLIC` ensures that notifications and live activities are allowed to show content on the lock screen for supported ROMs/regions.

### 🖼️ Screenshots
| Settings Screen | Onboarding Screen |
|:---:|:---:|
| *(Attach your settings screenshot here)* | *(Attach your onboarding screenshot here)* |
